### PR TITLE
Remove optional Android permissions from Settings.

### DIFF
--- a/Settings/Refractored.Xam.Settings.Android/Properties/AssemblyInfo.cs
+++ b/Settings/Refractored.Xam.Settings.Android/Properties/AssemblyInfo.cs
@@ -28,7 +28,3 @@ using Android.App;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.3.0.0")]
 [assembly: AssemblyFileVersion("1.3.0.0")]
-
-// Add some common permissions, these can be removed if not needed
-[assembly: UsesPermission(Android.Manifest.Permission.Internet)]
-[assembly: UsesPermission(Android.Manifest.Permission.WriteExternalStorage)]


### PR DESCRIPTION
## Issue

It looks like the Settings plug-in is asking for Android permissions that it doesn't really need. This change is just removing those from being built into the assembly for anyone consuming it.
## Background

I was putting together a super-simple app that didn't use any explicit permissions. After a number of changes, including adding settings (which was insanely easy with this NuGet package BTW, thank you), Play Store was telling me my app added two permissions. I tracked it down to this [`AssemblyInfo.cs` file](https://github.com/jamesmontemagno/Xam.PCL.Plugins/blob/55d9141aa1b0921cfc9a6582204877a500e37c20/Settings/Refractored.Xam.Settings.Android/Properties/AssemblyInfo.cs#L33).

Without prior experience with Android's `PreferenceManager` class, I wasn't sure if the `WriteExternalStorage` permission was needed. There wasn't any mention of it being required on the Android [PreferenceManager page](http://developer.android.com/reference/android/preference/PreferenceManager.html). I was already fairly certain the `Internet` permission wasn't required.

I spun up a version of the Setting project that didn't have these permissions and gave the resulting DLLs a run in my app. Everything worked just fine without them.
## Potential source

It looks like this could have just been a side-effect of starting from an [older Xamarin.Android template where these permissions are included by default](https://bugzilla.xamarin.com/show_bug.cgi?id=19785).
## Messages, too?

Along the same lines, it looks like the [Messages is also asking for those permissions](https://github.com/patridge/Xam.PCL.Plugins/blob/master/Messages/Refractored.Xam.Messages.Android/Properties/AssemblyInfo.cs#L33). Since I don't have an app consuming that plug-in yet, I didn't feel comfortable changing it.
