### PR TITLE
fixed waiting for initite Timeout where compared to -1

### DIFF
--- a/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone8/SinglePositionListener.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone8/SinglePositionListener.cs
@@ -102,7 +102,7 @@ namespace Geolocator.Plugin
       if (e.Position.Location.IsUnknown)
         return;
 
-      bool isRecent = (e.Position.Timestamp - this.start).TotalMilliseconds < this.timeout;
+      bool isRecent = timeout == Timeout.Infinite || (e.Position.Timestamp - this.start).TotalMilliseconds < this.timeout;
 
       if (e.Position.Location.HorizontalAccuracy <= this.desiredAccuracy && isRecent)
         this.tcs.TrySetResult(GeolocatorImplementation.GetPosition(e.Position));


### PR DESCRIPTION
There is a bug in WP8 at least - Timeout.Infite is -1 and thus isRecent is never true. Cheers.