### PR TITLE
Handle no timeout on winstore/wp8.1

### DIFF
--- a/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/Timeout.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/Timeout.cs
@@ -33,7 +33,7 @@ namespace Geolocator.Plugin
       if (timesup == null)
         throw new ArgumentNullException("timesup");
       
-      Task.Delay(TimeSpan.FromSeconds(timeout), this.canceller.Token)
+      Task.Delay(TimeSpan.FromMilliseconds(timeout), this.canceller.Token)
           .ContinueWith(t =>
           {
               if (!t.IsCanceled)
@@ -48,6 +48,6 @@ namespace Geolocator.Plugin
 
     private volatile readonly CancellationTokenSource canceller = new CancellationTokenSource();
 
-        public const int Infite = -1;
+    public const int Infite = -1;
   }
 }

--- a/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/Timeout.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/Timeout.cs
@@ -25,6 +25,8 @@ namespace Geolocator.Plugin
 
     public Timeout(int timeout, Action timesup)
     {
+      if (timeout == Infite)
+        return; // nothing to do
       if (timeout < 0)
         throw new ArgumentOutOfRangeException("timeout");
       if (timesup == null)

--- a/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/Timeout.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/Timeout.cs
@@ -33,8 +33,6 @@ namespace Geolocator.Plugin
       if (timesup == null)
         throw new ArgumentNullException("timesup");
       
-      this.canceller = new CancellationTokenSource();
-
       Task.Delay(TimeSpan.FromSeconds(timeout), this.canceller.Token)
           .ContinueWith(t =>
           {
@@ -48,8 +46,8 @@ namespace Geolocator.Plugin
       this.canceller.Cancel();
     }
 
-    private volatile readonly CancellationTokenSource canceller;
+    private volatile readonly CancellationTokenSource canceller = new CancellationTokenSource();
 
-    public const int Infite = -1;
+        public const int Infite = -1;
   }
 }


### PR DESCRIPTION
Hey James,

I noticed that the `Timeout` class used in Windows Store/WP8.1 didn't handle the default `-1`/infinite timeout and would throw `ArgumentOutOfRangeException`, so I added a catch for that. 

While I was in there, I also changed the timeout to use a `Task.Delay`/`CancellationToken` approach; if you'd prefer it how it was I can back that part out. 

Thanks for a useful, no-fuss plugin!