### PR TITLE
Fixed Windows 8.1 Bug:

### DIFF
--- a/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/GeolocatorImplementation.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/GeolocatorImplementation.cs
@@ -32,7 +32,6 @@ namespace Geolocator.Plugin
     public GeolocatorImplementation()
 		{
       DesiredAccuracy = 50;
-			this.locator.StatusChanged += OnLocatorStatusChanged;
 		}
     /// <inheritdoc/>
 		public event EventHandler<PositionEventArgs> PositionChanged;
@@ -145,9 +144,10 @@ namespace Geolocator.Plugin
 			this.isListening = true;
 
 			var loc = GetGeolocator();
+      loc.ReportInterval = (uint)minTime;
+      loc.MovementThreshold = minDistance;
 			loc.PositionChanged += OnLocatorPositionChanged;
-			loc.ReportInterval = (uint)minTime;
-			loc.MovementThreshold = minDistance;
+      loc.StatusChanged += OnLocatorStatusChanged;
 		}
     /// <inheritdoc/>
 		public void StopListening()

--- a/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/Timeout.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/Timeout.cs
@@ -46,7 +46,7 @@ namespace Geolocator.Plugin
       this.canceller.Cancel();
     }
 
-    private volatile readonly CancellationTokenSource canceller = new CancellationTokenSource();
+    private readonly CancellationTokenSource canceller = new CancellationTokenSource();
 
     public const int Infite = -1;
   }


### PR DESCRIPTION
Hi James

This wouldn't work on a Windows 8.1 device due to the reasons mentioned below. I've made the changes, tested on an actual device and it works now.

Cheers
-doug

Operation aborted - You must set the MovementThreshold property or the ReportInterval property before adding event handlers.

Also, it would not compile the timeout class - an object cannot be marked as both readonly and volatile