### PR TITLE
StartListening method returns error on Win

### DIFF
--- a/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/GeolocatorImplementation.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/GeolocatorImplementation.cs
@@ -144,7 +144,7 @@ namespace Geolocator.Plugin
         {
             if (minTime < 0)
                 throw new ArgumentOutOfRangeException("minTime");
-            if (minTime < minDistance)
+            if (minDistance < 0)
                 throw new ArgumentOutOfRangeException("minDistance");
             if (this.isListening)
                 throw new InvalidOperationException();


### PR DESCRIPTION
In the StartListening method an ArgumentOutOfRangeException is thrown if minTime is less than minDistance, instead of minDistance less than 0.