### PR TITLE
Fixes issue where static ctor called on thread doesn't allow callbacks

### DIFF
--- a/Connectivity/Connectivity/Connectivity.Plugin.iOS/Reachability.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.iOS/Reachability.cs
@@ -157,7 +157,7 @@ namespace Connectivity.Plugin
       {
         adHocWiFiNetworkReachability = new NetworkReachability(new IPAddress(new byte[] { 169, 254, 0, 0 }));
         adHocWiFiNetworkReachability.SetNotification(OnChange);
-        adHocWiFiNetworkReachability.Schedule(CFRunLoop.Current, CFRunLoop.ModeDefault);
+        adHocWiFiNetworkReachability.Schedule(CFRunLoop.Main, CFRunLoop.ModeDefault);
       }
 
       if (!adHocWiFiNetworkReachability.TryGetFlags(out flags))
@@ -174,7 +174,7 @@ namespace Connectivity.Plugin
       {
         defaultRouteReachability = new NetworkReachability(new IPAddress(0));
         defaultRouteReachability.SetNotification(OnChange);
-        defaultRouteReachability.Schedule(CFRunLoop.Current, CFRunLoop.ModeDefault);
+        defaultRouteReachability.Schedule(CFRunLoop.Main, CFRunLoop.ModeDefault);
       }
       if (!defaultRouteReachability.TryGetFlags(out flags))
         return false;
@@ -200,7 +200,7 @@ namespace Connectivity.Plugin
         reachable = remoteHostReachability.TryGetFlags(out flags);
 
         remoteHostReachability.SetNotification(OnChange);
-        remoteHostReachability.Schedule(CFRunLoop.Current, CFRunLoop.ModeDefault);
+        remoteHostReachability.Schedule(CFRunLoop.Main, CFRunLoop.ModeDefault);
       }
       else
         reachable = remoteHostReachability.TryGetFlags(out flags);


### PR DESCRIPTION
This fixes an issue I ran into similar to issue #104 -- I was running into an issue where the callbacks to Reachability weren't being fired. The static constructor was being initialized in an async / await method on another thread, and after the thread's lifecycle ends, the callbacks stopped occurring.

By switching the `CFRunLoop.Current` to `CFRunLoop.Main`, this solves the issue. I believe `CFRunLoop.Main` is more appropriate here since your objects are static and you cannot guarantee they will be called from the main thread.