### PR TITLE
Fix proposal for issue #134 - TakePictureAsync landscape issue

### DIFF
--- a/Media/Media/Media.Plugin.Android/MediaImplementation.cs
+++ b/Media/Media/Media.Plugin.Android/MediaImplementation.cs
@@ -201,8 +201,7 @@ namespace Plugin.Media
 
             var media = await TakeMediaAsync("image/*", MediaStore.ActionImageCapture, options);
             
-            if(options.AutoFixOrientation)
-                await FixOrientationAsync(media.Path);
+            await FixOrientationAsync(media.Path);
             
             return media;
         }


### PR DESCRIPTION
Fix proposal for TakePictureAsync: image "always" stored in landscape even when taken in portrait  #134 android issue

I Fixed this issue altering the ***TakePhotoAsync*** method to rotate the captured image(onto disk)
if necessary