### PR TITLE
CrossVibrate class. Wrong NuGet package name in the NotImplementedException message

### DIFF
--- a/Vibrate/Refractored.Xam.Vibrate/CrossVibrate.cs
+++ b/Vibrate/Refractored.Xam.Vibrate/CrossVibrate.cs
@@ -37,7 +37,7 @@ namespace Plugin.Vibrate
 
       internal static Exception NotImplementedInReferenceAssembly()
       {
-        return new NotImplementedException("This functionality is not implemented in the portable version of this assembly.  You should reference the Xam.Plugins.TextToSpeech NuGet package from your main application project in order to reference the platform-specific implementation.");
+        return new NotImplementedException("This functionality is not implemented in the portable version of this assembly.  You should reference the Xam.Plugins.Vibrate NuGet package from your main application project in order to reference the platform-specific implementation.");
       }
     }
 }


### PR DESCRIPTION
After reading your blog post about creating Xamarin plugins, I was having a look to the Vibrate plugin and saw an error in the message for the NotImplementedException in the CrossVibrate class. 
I thought it could be a good idea to put the right package name. 