### PR TITLE
Fix proposal for issue #147 Bug On External Map IOS

### DIFF
--- a/ExternalMaps/ExternalMaps/ExternalMaps.Plugin.iOS/ExternalMapsImplementation.cs
+++ b/ExternalMaps/ExternalMaps/ExternalMaps.Plugin.iOS/ExternalMapsImplementation.cs
@@ -94,8 +94,19 @@ namespace Plugin.ExternalMaps
       };
 
       var coder = new CLGeocoder();
-      var placemarks = await coder.GeocodeAddressAsync(placemarkAddress.Dictionary);
+      
+      CLPlacemark[] placemarks = new CLPlacemark[0];
 
+      try
+      {
+        placemarks = await coder.GeocodeAddressAsync(placemarkAddress.Dictionary);
+      }
+      catch (Exception)
+      {
+        Debug.WriteLine("Unable to get geocode address from address");
+        return;
+      }   
+      
       if(placemarks.Length == 0)
       {
         Debug.WriteLine("Unable to get geocode address from address");


### PR DESCRIPTION
Catches the 'Foundation.NSErrorException' that occurs when trying to geocode an invalid address.