### PR TITLE
Fix checking photos permission on iOS

### DIFF
--- a/Permissions/Plugin.Permissions.iOSUnified/PermissionsImplementation.cs
+++ b/Permissions/Plugin.Permissions.iOSUnified/PermissionsImplementation.cs
@@ -70,6 +70,8 @@ namespace Plugin.Permissions
                 //    break;
                 //case Permission.NotificationsRemote:
                 //    break;
+                case Permission.Photos:
+                    return Task.FromResult(PhotosPermissionStatus);
                 case Permission.Reminders:
                     return Task.FromResult(GetEventPermissionStatus(EKEntityType.Reminder));
                 case Permission.Sensors:


### PR DESCRIPTION
Hey James!

When checking for Photos permission on iOS with the latest version of Permissions Plugin, the result is ALWAYS `PermissionStatus.Granted`, because actually there is no check happening. I don't know when it fell out exactly, but I suggest releasing a hotfix quickly ;-).
