### PR TITLE
Update MediaPickerDelegate.cs

### DIFF
--- a/Media/Media/Media.Plugin.iOS/MediaPickerDelegate.cs
+++ b/Media/Media/Media.Plugin.iOS/MediaPickerDelegate.cs
@@ -72,7 +72,8 @@ namespace Plugin.Media
 
         public override async void FinishedPickingMedia(UIImagePickerController picker, NSDictionary info)
         {
-
+            RemoveOrientationChangeObserverAndNotifications();
+            
             MediaFile mediaFile;
             switch ((NSString)info[UIImagePickerController.MediaType])
             {
@@ -103,6 +104,8 @@ namespace Plugin.Media
 
         public override void Canceled(UIImagePickerController picker)
         {
+            RemoveOrientationChangeObserverAndNotifications();
+            
             if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
             {
                 UIApplication.SharedApplication.SetStatusBarStyle(MediaImplementation.StatusBarStyle, false);
@@ -175,11 +178,6 @@ namespace Plugin.Media
             }
             else
             {
-                NSNotificationCenter.DefaultCenter.RemoveObserver(observer);
-                UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
-
-                observer.Dispose();
-
                 if (Popover != null)
                 {
                     Popover.Dismiss(animated: true);
@@ -194,6 +192,13 @@ namespace Plugin.Media
                     picker.Dispose();
                 }
             }
+        }
+        
+        private void RemoveOrientationChangeObserverAndNotifications()
+        {
+            UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
+            NSNotificationCenter.DefaultCenter.RemoveObserver(observer);
+            observer.Dispose();
         }
 
         private void DidRotate(NSNotification notice)

--- a/Media/Media/Media.Plugin.iOS/MediaPickerDelegate.cs
+++ b/Media/Media/Media.Plugin.iOS/MediaPickerDelegate.cs
@@ -196,9 +196,12 @@ namespace Plugin.Media
         
         private void RemoveOrientationChangeObserverAndNotifications()
         {
-            UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
-            NSNotificationCenter.DefaultCenter.RemoveObserver(observer);
-            observer.Dispose();
+            if (viewController != null)
+            {
+                UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
+                NSNotificationCenter.DefaultCenter.RemoveObserver(observer);
+                observer.Dispose();
+            }
         }
 
         private void DidRotate(NSNotification notice)


### PR DESCRIPTION
Fix for orientation change issue, EXC_BAD_ACCESS (SIGABRT), during Dismiss on iOS. 
Did not change the Andorid or WPhone files, because i cannot test them, and do not know if the bug exists there.

The problem was that the plugin did not stop listening for orientation notifications on time, so the user could trigger the notification to be sent to the view, but in the time it came, picker dispose already executed. This change handles the removal of notifications and observer dispose first thing after clicking "Cancel" or "Use Picture".