### PR TITLE
Fix incorrect default in geolocator listener settings.

### DIFF
--- a/Geolocator/Geolocator/Geolocator.Plugin.Abstractions/ListenerSettings.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.Abstractions/ListenerSettings.cs
@@ -15,7 +15,7 @@ namespace Plugin.Geolocator.Abstractions
 		/// <summary>
 		/// Gets or sets whether location updates should be paused automatically when the location is unlikely to change (>= iOS 6). Default:  true
 		/// </summary>
-		public bool PauseLocationUpdatesAutomatically { get; set; } = false;
+		public bool PauseLocationUpdatesAutomatically { get; set; } = true;
 
 		/// <summary>
 		/// Gets or sets the activity type that should be used to determine when to automatically pause location updates (>= iOS 6). Default:  ActivityType.Other


### PR DESCRIPTION
Please take a moment to fill out the following (change to preview to check or place x in []):

Fixes ----.

Changes Proposed in this pull request:

Fixed incorrect default in listener settings.

This fixes/implements:
- [x] Bug
- [ ] Feature Request

Which plugin does this impact:
- [ ] Battery
- [ ] Connectivity
- [ ] Contacts
- [ ] DeviceInfo
- [ ] ExternalMaps
- [x] Geolocator
- [ ] Media
- [ ] Permissions
- [ ] Settings
- [ ] Text To Speech
- [ ] Vibrate
- Other:
