### PR TITLE
Fixed WP81 StopListeningAsync

### DIFF
--- a/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/GeolocatorImplementation.cs
+++ b/Geolocator/Geolocator/Geolocator.Plugin.WindowsPhone81/GeolocatorImplementation.cs
@@ -161,6 +161,7 @@ namespace Plugin.Geolocator
                 return Task.FromResult(true);
 
             locator.PositionChanged -= OnLocatorPositionChanged;
+            locator.StatusChanged -= OnLocatorStatusChanged;
             isListening = false;
 
             return Task.FromResult(true);


### PR DESCRIPTION
Changes Proposed in this pull request:
- Fixed GeolocatorImplementation.StopListeningAsync(): it has to unregister from locator.StatusChanged as well to actually stop listening on WindowsPhone!


This fixes/implements:
- [x] Bug
- [ ] Feature Request

Which plugin does this impact:
- [ ] Battery
- [ ] Connectivity
- [ ] Contacts
- [ ] DeviceInfo
- [ ] ExternalMaps
- [x] Geolocator
- [ ] Media
- [ ] Permissions
- [ ] Settings
- [ ] Text To Speech
- [ ] Vibrate
- Other:

