### PR TITLE
Update IsRemoteReachable documentation and trim end of hostname of any slashes

### DIFF
--- a/Connectivity/Connectivity/Connectivity.Plugin.Android/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.Android/ConnectivityImplementation.cs
@@ -114,7 +114,7 @@ namespace Plugin.Connectivity
         /// <summary> 
         /// Tests if a remote host name is reachable 
         /// </summary>
-        /// <param name="host">Host name can be a remote IP or URL of website (no http:// or www.)</param>
+        /// <param name="host">Host name can be a remote IP or URL of website</param>
         /// <param name="port">Port to attempt to check is reachable.</param>
         /// <param name="msTimeout">Timeout in milliseconds.</param>
         /// <returns></returns>
@@ -130,7 +130,8 @@ namespace Plugin.Connectivity
             host = host.Replace("http://www.", string.Empty).
               Replace("http://", string.Empty).
               Replace("https://www.", string.Empty).
-              Replace("https://", string.Empty);
+              Replace("https://", string.Empty).
+              TrimEnd('/');
 
             return await Task.Run(async () =>
             {

--- a/Connectivity/Connectivity/Connectivity.Plugin.Mac/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.Mac/ConnectivityImplementation.cs
@@ -75,7 +75,7 @@ namespace Plugin.Connectivity
 		/// <summary>
 		/// Tests if a remote host name is reachable 
 		/// </summary>
-		/// <param name="host">Host name can be a remote IP or URL of website (no http:// or www.</param>
+		/// <param name="host">Host name can be a remote IP or URL of website</param>
 		/// <param name="port">Port to attempt to check is reachable.</param>
 		/// <param name="msTimeout">Timeout in milliseconds.</param>
 		/// <returns></returns>
@@ -88,9 +88,10 @@ namespace Plugin.Connectivity
 				return false;
 
 			host = host.Replace ("http://www.", string.Empty).
-              Replace ("http://", string.Empty).
-              Replace ("https://www.", string.Empty).
-              Replace ("https://", string.Empty);
+              		Replace ("http://", string.Empty).
+              		Replace ("https://www.", string.Empty).
+              		Replace ("https://", string.Empty).
+              		TrimEnd("/");
 
 			return await Task.Run (() => {
 				try {

--- a/Connectivity/Connectivity/Connectivity.Plugin.Mac/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.Mac/ConnectivityImplementation.cs
@@ -91,7 +91,7 @@ namespace Plugin.Connectivity
               		Replace ("http://", string.Empty).
               		Replace ("https://www.", string.Empty).
               		Replace ("https://", string.Empty).
-              		TrimEnd("/");
+              		TrimEnd('/');
 
 			return await Task.Run (() => {
 				try {

--- a/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone8/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone8/ConnectivityImplementation.cs
@@ -133,7 +133,7 @@ namespace Plugin.Connectivity
                Replace("http://", string.Empty).
                Replace("https://www.", string.Empty).
                Replace("https://", string.Empty).
-               TrimEnd("/");
+               TrimEnd('/');
 
             return await Task.Run(() =>
             {

--- a/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone8/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone8/ConnectivityImplementation.cs
@@ -117,7 +117,7 @@ namespace Plugin.Connectivity
         /// <summary>
         /// Tests if a remote host name is reachable
         /// </summary>
-        /// <param name="host">Host name can be a remote IP or URL of website (no http:// or www.)</param>
+        /// <param name="host">Host name can be a remote IP or URL of website</param>
         /// <param name="port">Port to attempt to check is reachable.</param>
         /// <param name="msTimeout">Timeout in milliseconds.</param>
         /// <returns></returns>
@@ -132,7 +132,8 @@ namespace Plugin.Connectivity
             host = host.Replace("http://www.", string.Empty).
                Replace("http://", string.Empty).
                Replace("https://www.", string.Empty).
-               Replace("https://", string.Empty);
+               Replace("https://", string.Empty).
+               TrimEnd("/");
 
             return await Task.Run(() =>
             {

--- a/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
@@ -119,7 +119,7 @@ namespace Plugin.Connectivity
               Replace("http://", string.Empty).
               Replace("https://www.", string.Empty).
               Replace("https://", string.Empty).
-              TrimEnd("/");
+              TrimEnd('/');
 
             try
             {

--- a/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
@@ -103,7 +103,7 @@ namespace Plugin.Connectivity
         /// <summary>
         /// Tests if a remote host name is reachable 
         /// </summary>
-        /// <param name="host">Host name can be a remote IP or URL of website (no http:// or www.)</param>
+        /// <param name="host">Host name can be a remote IP or URL of website</param>
         /// <param name="port">Port to attempt to check is reachable.</param>
         /// <param name="msTimeout">Timeout in milliseconds.</param>
         /// <returns></returns>
@@ -118,7 +118,8 @@ namespace Plugin.Connectivity
             host = host.Replace("http://www.", string.Empty).
               Replace("http://", string.Empty).
               Replace("https://www.", string.Empty).
-              Replace("https://", string.Empty);
+              Replace("https://", string.Empty).
+              TrimEnd("/");
 
             try
             {

--- a/Connectivity/Connectivity/Connectivity.Plugin.iOS/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.iOS/ConnectivityImplementation.cs
@@ -93,7 +93,7 @@ namespace Plugin.Connectivity
               Replace("http://", string.Empty).
               Replace("https://www.", string.Empty).
               Replace("https://", string.Empty).
-              TrimEnd("/");
+              TrimEnd('/');
 
             return await Task.Run(() =>
             {

--- a/Connectivity/Connectivity/Connectivity.Plugin.iOS/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.iOS/ConnectivityImplementation.cs
@@ -77,7 +77,7 @@ namespace Plugin.Connectivity
         /// <summary>
         /// Tests if a remote host name is reachable 
         /// </summary>
-        /// <param name="host">Host name can be a remote IP or URL of website (no http:// or www.</param>
+        /// <param name="host">Host name can be a remote IP or URL of website</param>
         /// <param name="port">Port to attempt to check is reachable.</param>
         /// <param name="msTimeout">Timeout in milliseconds.</param>
         /// <returns></returns>
@@ -92,7 +92,8 @@ namespace Plugin.Connectivity
             host = host.Replace("http://www.", string.Empty).
               Replace("http://", string.Empty).
               Replace("https://www.", string.Empty).
-              Replace("https://", string.Empty);
+              Replace("https://", string.Empty).
+              TrimEnd("/");
 
             return await Task.Run(() =>
             {


### PR DESCRIPTION
Changes Proposed in this pull request:
- Remove the "(no http:// or www.)" in the description of IsRemoteReachable as the method is already doing that.
- Trim the end of the host name in IsRemoteReachable of any slashes as the method fails if they are there

This fixes/implements:
- [x] Improvement

Which plugin does this impact:
- [x] Connectivity
