### PR TITLE
Changing IsConnected getter to directly use System.Net.NetworkInforma…

### DIFF
--- a/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
+++ b/Connectivity/Connectivity/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Plugin.Connectivity.Abstractions;
-using Windows.Networking.Connectivity;
-using System.Threading.Tasks;
-using Windows.Networking.Sockets;
-using Windows.Networking;
 using System.Diagnostics;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Threading.Tasks;
+using Plugin.Connectivity.Abstractions;
 using Windows.ApplicationModel.Core;
+using Windows.Networking;
+using Windows.Networking.Connectivity;
+using Windows.Networking.Sockets;
 
 namespace Plugin.Connectivity
 {
@@ -56,11 +57,7 @@ namespace Plugin.Connectivity
         {
             get
             {
-                var profile = NetworkInformation.GetInternetConnectionProfile();
-                if (profile == null)
-                    isConnected = false;
-                else
-                    isConnected = profile.GetNetworkConnectivityLevel() != NetworkConnectivityLevel.None;
+                isConnected = NetworkInterface.GetIsNetworkAvailable();
 
                 return isConnected;
             }


### PR DESCRIPTION
Please take a moment to fill out the following (change to preview to check or place x in []):

Fixes #244  .

Changes Proposed in this pull request:
- Change implementatio of `IsConnected` property getter on WinPhone 8.1 to use directly System.Net.NetworkInformation.NetworkInterface.GetIsNetworkAvailable()

This fixes/implements:
- [X] Bug
- [ ] Feature Request

Which plugin does this impact:
- [ ] Battery
- [X] Connectivity
- [ ] Contacts
- [ ] DeviceInfo
- [ ] ExternalMaps
- [ ] Geolocator
- [ ] Media
- [ ] Permissions
- [ ] Settings
- [ ] Text To Speech
- [ ] Vibrate
- Other:

which I experienced works correctly on devices as Lumia 635, 925 when in airplane mode.