### PR TITLE
Added convenience method with combined check and request of permissions

### DIFF
--- a/Permissions/Plugin.Permissions.Abstractions/IPermissions.cs
+++ b/Permissions/Plugin.Permissions.Abstractions/IPermissions.cs
@@ -29,5 +29,12 @@ namespace Plugin.Permissions.Abstractions
         /// <returns>The permissions and their status.</returns>
         /// <param name="permissions">Permissions to request.</param>
         Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions);
+
+        /// <summary>
+        /// Checks statusses of given <paramref name="requests"/> permissions and requests them if not granted.
+        /// </summary>
+        /// <param name="requests">A composite result which is <c>true</c> if all are granted and <c>false</c> otherwise.</param>
+        /// <returns>A composite results object with some convenience methods.</returns>
+        Task<PermissionsResult> HasPermissionAsync(params Permission[] requests);
     }
 }

--- a/Permissions/Plugin.Permissions.Abstractions/PermissionsBase.cs
+++ b/Permissions/Plugin.Permissions.Abstractions/PermissionsBase.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Plugin.Permissions.Abstractions
+{
+    public abstract class PermissionsBase : IPermissions
+    {
+        public abstract Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission);
+
+        public abstract Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission);
+
+        public abstract Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions);
+
+        public async Task<PermissionsResult> HasPermissionAsync(params Permission[] requests)
+        {
+            List<Permission> missing = new List<Permission>();
+            foreach (var permission in requests)
+            {
+                var status = await CheckPermissionStatusAsync(permission).ConfigureAwait(false);
+                if (status != PermissionStatus.Granted)
+                {
+                    // Can't use console as in other parts of the plugin here, would require different design.
+                    Debug.WriteLine($"Currently does not have {Enum.GetName(typeof(Permission), permission)} permissions, requesting permission.");
+                    missing.Add(permission);
+                }
+            }
+            if (missing.Count == 0) { return PermissionsResult.AllGranted(requests); }
+
+            return new PermissionsResult(await RequestPermissionsAsync(missing.ToArray()));
+        }
+    }
+}

--- a/Permissions/Plugin.Permissions.Abstractions/PermissionsResult.cs
+++ b/Permissions/Plugin.Permissions.Abstractions/PermissionsResult.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Plugin.Permissions.Abstractions
+{
+    public class PermissionsResult
+    {
+        readonly IDictionary<Permission, PermissionStatus> _requestStatuses;
+
+        public PermissionsResult(IDictionary<Permission, PermissionStatus> requestStatuses)
+        {
+            _requestStatuses = requestStatuses ?? new Dictionary<Permission, PermissionStatus>();
+        }
+
+        /// <summary>
+        /// Creates a result with all given permissions granted.
+        /// </summary>
+        /// <param name="permissions">The permissions to flag as granted.</param>
+        /// <returns>A result with all given permissions granted.</returns>
+        public static PermissionsResult AllGranted(IEnumerable<Permission> permissions) 
+            => new PermissionsResult(permissions.ToDictionary(p => p, _ => PermissionStatus.Granted));
+
+        public static implicit operator bool(PermissionsResult result)
+        {
+            return result.IsSuccesful;
+        }
+
+        public bool IsSuccesful => _requestStatuses.All(permstatus => permstatus.Value == PermissionStatus.Granted);
+
+        public IDictionary<Permission, PermissionStatus> RequestStatuses => _requestStatuses;
+
+        // Not sure if you'd want something like this.
+        public IEnumerable<Permission> UnsuccesfulRequests => _requestStatuses.Where(rs => rs.Value != PermissionStatus.Granted).Select(kv => kv.Key);
+    }
+}

--- a/Permissions/Plugin.Permissions.Abstractions/Plugin.Permissions.Abstractions.csproj
+++ b/Permissions/Plugin.Permissions.Abstractions/Plugin.Permissions.Abstractions.csproj
@@ -39,6 +39,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IPermissions.cs" />
+    <Compile Include="PermissionsBase.cs" />
+    <Compile Include="PermissionsResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PermissionEnums.cs" />
   </ItemGroup>

--- a/Permissions/Plugin.Permissions.Android/PermissionsImplementation.cs
+++ b/Permissions/Plugin.Permissions.Android/PermissionsImplementation.cs
@@ -16,7 +16,7 @@ namespace Plugin.Permissions
     /// <summary>
     /// Implementation for Feature
     /// </summary>
-    public class PermissionsImplementation : IPermissions
+    public class PermissionsImplementation : PermissionsBase
     {
 
         object locker = new object();
@@ -38,7 +38,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns>True or false to show rationale</returns>
         /// <param name="permission">Permission to check.</param>
-        public Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission)
+        public override Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission)
         {
             var activity = CrossCurrentActivity.Current.Activity;
             if(activity == null)
@@ -77,7 +77,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns><c>true</c> if this instance has permission the specified permission; otherwise, <c>false</c>.</returns>
         /// <param name="permission">Permission to check.</param>
-        public Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
+        public override Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
         {
             var names = GetManifestNames(permission);
 
@@ -115,7 +115,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns>The permissions and their status.</returns>
         /// <param name="permissions">Permissions to request.</param>
-        public async Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions)
+        public override async Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions)
         {
             if (tcs != null && !tcs.Task.IsCompleted)
             {

--- a/Permissions/Plugin.Permissions.WindowsPhone8/PermissionsImplementation.cs
+++ b/Permissions/Plugin.Permissions.WindowsPhone8/PermissionsImplementation.cs
@@ -10,7 +10,7 @@ namespace Plugin.Permissions
     /// <summary>
     /// Implementation for Permissions
     /// </summary>
-    public class PermissionsImplementation : IPermissions
+    public class PermissionsImplementation : PermissionsBase
     {
         /// <summary>
         /// Request to see if you should show a rationale for requesting permission
@@ -18,7 +18,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns>True or false to show rationale</returns>
         /// <param name="permission">Permission to check.</param>
-        public Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission)
+        public override Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission)
         {
             return Task.FromResult(false);
         }
@@ -28,7 +28,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns><c>true</c> if this instance has permission the specified permission; otherwise, <c>false</c>.</returns>
         /// <param name="permission">Permission to check.</param>
-        public Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
+        public override Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
         {
             return Task.FromResult(PermissionStatus.Granted);
         }
@@ -38,7 +38,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns>The permissions and their status.</returns>
         /// <param name="permissions">Permissions to request.</param>
-        public Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions)
+        public override Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions)
         {
             var results = permissions.ToDictionary(permission => permission, permission => PermissionStatus.Granted);
             return Task.FromResult(results);

--- a/Permissions/Plugin.Permissions.WindowsPhone81/PermissionsImplementation.cs
+++ b/Permissions/Plugin.Permissions.WindowsPhone81/PermissionsImplementation.cs
@@ -10,7 +10,7 @@ namespace Plugin.Permissions
     /// <summary>
     /// Implementation for Permissions
     /// </summary>
-    public class PermissionsImplementation : IPermissions
+    public class PermissionsImplementation : PermissionsBase
     {
         /// <summary>
         /// Request to see if you should show a rationale for requesting permission
@@ -18,7 +18,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns>True or false to show rationale</returns>
         /// <param name="permission">Permission to check.</param>
-        public Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission)
+        public override Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission)
         {
             return Task.FromResult(false);
         }
@@ -28,7 +28,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns><c>true</c> if this instance has permission the specified permission; otherwise, <c>false</c>.</returns>
         /// <param name="permission">Permission to check.</param>
-        public Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
+        public override Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
         {
             return Task.FromResult(PermissionStatus.Granted);
         }
@@ -38,7 +38,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns>The permissions and their status.</returns>
         /// <param name="permissions">Permissions to request.</param>
-        public Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions)
+        public override Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions)
         {
             var results = permissions.ToDictionary(permission => permission, permission => PermissionStatus.Granted);
             return Task.FromResult(results);

--- a/Permissions/Plugin.Permissions.iOSUnified/PermissionsImplementation.cs
+++ b/Permissions/Plugin.Permissions.iOSUnified/PermissionsImplementation.cs
@@ -18,7 +18,7 @@ namespace Plugin.Permissions
     /// <summary>
     /// Implementation for Permissions
     /// </summary>
-    public class PermissionsImplementation : IPermissions
+    public class PermissionsImplementation : PermissionsBase
     {
 
         CLLocationManager locationManager;
@@ -42,7 +42,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns>True or false to show rationale</returns>
         /// <param name="permission">Permission to check.</param>
-        public Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission)
+        public override Task<bool> ShouldShowRequestPermissionRationaleAsync(Permission permission)
         {
             return Task.FromResult(false);
         }
@@ -52,7 +52,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns><c>true</c> if this instance has permission the specified permission; otherwise, <c>false</c>.</returns>
         /// <param name="permission">Permission to check.</param>
-        public Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
+        public override Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
         {
             switch (permission)
             {
@@ -85,7 +85,7 @@ namespace Plugin.Permissions
         /// </summary>
         /// <returns>The permissions and their status.</returns>
         /// <param name="permissions">Permissions to request.</param>
-        public async Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions)
+        public override async Task<Dictionary<Permission, PermissionStatus>> RequestPermissionsAsync(params Permission[] permissions)
         {
             var results = new Dictionary<Permission, PermissionStatus>();
             foreach (var permission in permissions)


### PR DESCRIPTION
I found myself repeatedly writing the same code to check and if necessary request the permissions. I implemented this method in my own project by extending the interface and implementing it in a decorator style that simply proxies the other three functions of the interface. Here I put it in a base, since I seems to make sense to only have one interface exposed.

After having to modify all the implementations another style with a helper/wrapper might be more appropriate. But this does impede discoverability of the API whereas having it all on still a small interface does not. I at first like to know what you think of the general idea?

Changes Proposed in this pull request:
- Having a composite function that checks for one or more possible being granted and requests those which are not returning a composite result which a user can query for more info or simply use as a Boolean.

Which plugin does this impact:
- [ ] Battery
- [ ] Connectivity
- [ ] Contacts
- [ ] DeviceInfo
- [ ] ExternalMaps
- [ ] Geolocator
- [ ] Media
- [x] Permissions
- [ ] Settings
- [ ] Text To Speech
- [ ] Vibrate
- Other:

