### PR TITLE
UWP Changes to using IImageSourceHandler instead of if(image.Sour as …

### DIFF
--- a/ImageCircle/ImageCircle.Forms.Plugin.UWP/project.lock.json
+++ b/ImageCircle/ImageCircle.Forms.Plugin.UWP/project.lock.json
@@ -5,22 +5,22 @@
     "UAP,Version=v10.0": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -31,156 +31,210 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.dll": {},
           "lib/netcore50/System.Net.dll": {},
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {}
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Core.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Net.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Numerics.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Windows.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {},
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -191,8 +245,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -203,10 +257,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -217,30 +271,36 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -251,14 +311,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -269,12 +329,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -285,13 +345,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -302,7 +362,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -313,17 +373,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -334,10 +394,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -348,15 +408,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -371,28 +431,46 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Tools/4.0.0": {
@@ -401,80 +479,110 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -485,31 +593,37 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.IO.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -520,14 +634,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -538,21 +652,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -563,7 +677,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -574,15 +688,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -593,13 +707,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -610,11 +724,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -625,39 +739,45 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -668,13 +788,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -685,20 +805,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -709,8 +829,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -721,9 +841,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -734,8 +854,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -746,16 +866,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -766,8 +886,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -778,10 +898,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -792,10 +912,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -806,9 +926,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -819,11 +939,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -834,51 +954,57 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
         },
         "runtime": {
           "lib/netcore50/System.Private.DataContractSerialization.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -889,44 +1015,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -941,26 +1067,38 @@
         },
         "runtime": {
           "lib/netcore50/System.Private.Uri.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -971,55 +1109,67 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -1030,92 +1180,134 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
@@ -1124,14 +1316,20 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -1142,19 +1340,25 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -1165,43 +1369,55 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -1212,14 +1428,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -1230,7 +1446,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -1241,8 +1457,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -1253,8 +1469,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -1265,8 +1481,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -1277,8 +1493,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -1289,8 +1505,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -1301,28 +1517,34 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -1333,24 +1555,30 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -1361,24 +1589,30 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -1389,28 +1623,34 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -1421,14 +1661,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -1443,24 +1683,30 @@
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1471,17 +1717,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -1492,16 +1738,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1512,41 +1758,47 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -1554,22 +1806,22 @@
     "UAP,Version=v10.0/win10-arm": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -1580,125 +1832,129 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.dll": {},
           "lib/netcore50/System.Net.dll": {},
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {}
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR-arm": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.CoreCLR-arm/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1718,61 +1974,61 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -1783,8 +2039,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -1795,10 +2051,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -1809,11 +2065,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -1824,15 +2080,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -1843,14 +2099,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -1861,12 +2117,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -1877,13 +2133,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -1894,7 +2150,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -1905,17 +2161,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -1926,10 +2182,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -1940,15 +2196,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -1967,7 +2223,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -1978,7 +2234,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -1997,16 +2253,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -2017,18 +2273,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -2039,7 +2297,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -2050,8 +2308,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -2062,11 +2320,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -2077,12 +2335,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -2093,15 +2351,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-arm": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -2117,14 +2376,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2135,21 +2394,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -2160,7 +2419,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -2171,15 +2430,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -2190,13 +2449,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2207,11 +2466,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -2222,19 +2481,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -2245,16 +2506,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -2265,13 +2526,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -2282,20 +2543,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -2306,8 +2567,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -2318,9 +2579,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -2331,8 +2592,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -2343,16 +2604,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -2363,8 +2624,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -2375,10 +2636,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -2389,10 +2650,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -2403,9 +2664,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -2416,11 +2677,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -2431,24 +2692,26 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -2459,23 +2722,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -2486,44 +2749,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -2542,9 +2805,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -2555,9 +2818,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -2568,14 +2831,16 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -2586,11 +2851,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -2601,9 +2866,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2614,10 +2879,10 @@
       },
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -2628,13 +2893,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -2645,20 +2910,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -2669,8 +2934,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -2681,14 +2946,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -2699,9 +2964,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -2712,7 +2977,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -2723,7 +2988,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -2734,7 +2999,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -2745,10 +3010,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -2767,10 +3032,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -2781,7 +3046,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -2792,8 +3057,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -2804,8 +3069,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -2816,16 +3081,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -2836,11 +3101,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -2851,14 +3116,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -2869,7 +3134,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -2880,8 +3145,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -2892,8 +3157,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -2904,8 +3169,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -2916,8 +3181,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -2928,8 +3193,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -2940,7 +3205,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -2951,17 +3216,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -2972,8 +3237,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -2984,12 +3249,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -3000,8 +3265,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -3012,12 +3277,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -3028,7 +3293,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -3039,17 +3304,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -3060,14 +3325,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -3086,20 +3351,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -3110,17 +3375,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -3131,16 +3396,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -3151,22 +3416,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -3178,14 +3445,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -3193,22 +3460,22 @@
     "UAP,Version=v10.0/win10-arm-aot": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -3219,185 +3486,189 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
-          "runtimes/aot/lib/netcore50/mscorlib.dll": {},
           "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "runtimes/aot/lib/netcore50/System.Core.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
           "runtimes/aot/lib/netcore50/System.Net.dll": {},
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {}
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
+          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.Native": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.Native/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         }
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -3408,8 +3679,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -3420,10 +3691,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -3434,11 +3705,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -3449,15 +3720,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -3468,14 +3739,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -3486,12 +3757,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -3502,13 +3773,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -3519,7 +3790,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -3530,17 +3801,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -3551,10 +3822,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -3565,15 +3836,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -3592,7 +3863,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -3603,7 +3874,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -3622,16 +3893,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -3642,18 +3913,18 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -3664,7 +3935,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -3675,8 +3946,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -3687,11 +3958,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -3702,12 +3973,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -3718,15 +3989,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-arm": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -3742,14 +4014,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -3760,21 +4032,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -3785,7 +4057,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -3796,15 +4068,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -3815,13 +4087,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -3832,11 +4104,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -3847,19 +4119,19 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -3870,16 +4142,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -3890,13 +4162,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -3907,20 +4179,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -3931,8 +4203,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -3943,9 +4215,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -3956,8 +4228,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -3968,16 +4240,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -3988,8 +4260,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -4000,10 +4272,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -4014,10 +4286,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -4028,9 +4300,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -4041,11 +4313,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -4056,24 +4328,24 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -4084,23 +4356,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -4111,44 +4383,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -4167,9 +4439,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -4180,9 +4452,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -4193,14 +4465,14 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -4211,11 +4483,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -4226,9 +4498,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -4239,13 +4511,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -4256,20 +4528,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -4280,8 +4552,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -4292,14 +4564,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -4310,9 +4582,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -4323,7 +4595,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -4334,7 +4606,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -4345,7 +4617,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -4356,10 +4628,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -4378,10 +4650,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -4392,7 +4664,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -4403,8 +4675,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -4415,8 +4687,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -4427,16 +4699,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -4447,11 +4719,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -4462,14 +4734,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -4480,7 +4752,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -4491,8 +4763,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -4503,8 +4775,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -4515,8 +4787,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -4527,8 +4799,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -4539,8 +4811,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -4551,7 +4823,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -4562,17 +4834,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -4583,8 +4855,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -4595,12 +4867,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -4611,8 +4883,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -4623,12 +4895,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -4639,7 +4911,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -4650,17 +4922,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -4671,14 +4943,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -4697,20 +4969,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -4721,17 +4993,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -4742,16 +5014,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -4762,22 +5034,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -4789,14 +5063,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -4804,22 +5078,22 @@
     "UAP,Version=v10.0/win10-x64": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -4830,125 +5104,130 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.dll": {},
           "lib/netcore50/System.Net.dll": {},
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {}
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR-x64": "1.0.0",
+          "Microsoft.NETCore.Windows.ApiSets-x64": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.CoreCLR-x64/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -4968,41 +5247,41 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.NETCore.Windows.ApiSets-x64/1.0.0": {
@@ -5012,22 +5291,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -5038,8 +5317,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -5050,10 +5329,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -5064,11 +5343,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -5079,15 +5358,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -5098,14 +5377,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -5116,12 +5395,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -5132,13 +5411,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -5149,7 +5428,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -5160,17 +5439,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -5181,10 +5460,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -5195,15 +5474,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -5222,7 +5501,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -5233,7 +5512,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -5252,16 +5531,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -5272,18 +5551,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -5294,7 +5575,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -5305,8 +5586,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -5317,11 +5598,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -5332,12 +5613,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -5348,15 +5629,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-x64": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -5372,14 +5654,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -5390,21 +5672,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -5415,7 +5697,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -5426,15 +5708,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -5445,13 +5727,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -5462,11 +5744,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -5477,19 +5759,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -5500,16 +5784,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -5520,13 +5804,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -5537,20 +5821,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -5561,8 +5845,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -5573,9 +5857,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -5586,8 +5870,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -5598,16 +5882,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -5618,8 +5902,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -5630,10 +5914,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -5644,10 +5928,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -5658,9 +5942,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -5671,11 +5955,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -5686,24 +5970,26 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -5714,23 +6000,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -5741,44 +6027,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -5797,9 +6083,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -5810,9 +6096,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -5823,14 +6109,16 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -5841,11 +6129,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -5856,9 +6144,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -5869,10 +6157,10 @@
       },
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -5883,13 +6171,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -5900,20 +6188,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -5924,8 +6212,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -5936,14 +6224,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -5954,9 +6242,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -5967,7 +6255,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -5978,7 +6266,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -5989,7 +6277,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -6000,10 +6288,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -6022,10 +6310,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -6036,7 +6324,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -6047,8 +6335,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -6059,8 +6347,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -6071,16 +6359,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -6091,11 +6379,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -6106,14 +6394,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -6124,7 +6412,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -6135,8 +6423,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -6147,8 +6435,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -6159,8 +6447,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -6171,8 +6459,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -6183,8 +6471,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -6195,7 +6483,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -6206,17 +6494,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -6227,8 +6515,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -6239,12 +6527,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -6255,8 +6543,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -6267,12 +6555,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -6283,7 +6571,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -6294,17 +6582,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -6315,14 +6603,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -6341,20 +6629,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -6365,17 +6653,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -6386,16 +6674,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -6406,22 +6694,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -6433,14 +6723,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -6448,22 +6738,22 @@
     "UAP,Version=v10.0/win10-x64-aot": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -6474,185 +6764,189 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
-          "runtimes/aot/lib/netcore50/mscorlib.dll": {},
           "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "runtimes/aot/lib/netcore50/System.Core.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
           "runtimes/aot/lib/netcore50/System.Net.dll": {},
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {}
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
+          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.Native": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.Native/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         }
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -6663,8 +6957,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -6675,10 +6969,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -6689,11 +6983,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -6704,15 +6998,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -6723,14 +7017,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -6741,12 +7035,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -6757,13 +7051,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -6774,7 +7068,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -6785,17 +7079,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -6806,10 +7100,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -6820,15 +7114,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -6847,7 +7141,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -6858,7 +7152,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -6877,16 +7171,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -6897,18 +7191,18 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -6919,7 +7213,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -6930,8 +7224,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -6942,11 +7236,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -6957,12 +7251,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -6973,15 +7267,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-x64": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -6997,14 +7292,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -7015,21 +7310,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -7040,7 +7335,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -7051,15 +7346,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -7070,13 +7365,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -7087,11 +7382,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -7102,19 +7397,19 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -7125,16 +7420,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -7145,13 +7440,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -7162,20 +7457,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -7186,8 +7481,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -7198,9 +7493,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -7211,8 +7506,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -7223,16 +7518,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -7243,8 +7538,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -7255,10 +7550,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -7269,10 +7564,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -7283,9 +7578,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -7296,11 +7591,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -7311,24 +7606,24 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -7339,23 +7634,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -7366,44 +7661,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -7422,9 +7717,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -7435,9 +7730,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -7448,14 +7743,14 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -7466,11 +7761,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -7481,9 +7776,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -7494,13 +7789,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -7511,20 +7806,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -7535,8 +7830,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -7547,14 +7842,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -7565,9 +7860,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -7578,7 +7873,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -7589,7 +7884,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -7600,7 +7895,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -7611,10 +7906,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -7633,10 +7928,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -7647,7 +7942,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -7658,8 +7953,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -7670,8 +7965,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -7682,16 +7977,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -7702,11 +7997,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -7717,14 +8012,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -7735,7 +8030,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -7746,8 +8041,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -7758,8 +8053,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -7770,8 +8065,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -7782,8 +8077,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -7794,8 +8089,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -7806,7 +8101,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -7817,17 +8112,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -7838,8 +8133,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -7850,12 +8145,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -7866,8 +8161,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -7878,12 +8173,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -7894,7 +8189,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -7905,17 +8200,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -7926,14 +8221,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -7952,20 +8247,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -7976,17 +8271,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -7997,16 +8292,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -8017,22 +8312,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -8044,14 +8341,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -8059,22 +8356,22 @@
     "UAP,Version=v10.0/win10-x86": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -8085,125 +8382,130 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.dll": {},
           "lib/netcore50/System.Net.dll": {},
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {}
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR-x86": "1.0.0",
+          "Microsoft.NETCore.Windows.ApiSets-x86": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -8223,41 +8525,41 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
@@ -8267,22 +8569,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -8293,8 +8595,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -8305,10 +8607,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -8319,11 +8621,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -8334,15 +8636,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -8353,14 +8655,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -8371,12 +8673,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -8387,13 +8689,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -8404,7 +8706,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -8415,17 +8717,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -8436,10 +8738,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -8450,15 +8752,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -8477,7 +8779,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -8488,7 +8790,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -8507,16 +8809,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -8527,18 +8829,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -8549,7 +8853,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -8560,8 +8864,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -8572,11 +8876,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -8587,12 +8891,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -8603,15 +8907,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-x86": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -8627,14 +8932,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -8645,21 +8950,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -8670,7 +8975,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -8681,15 +8986,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -8700,13 +9005,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -8717,11 +9022,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -8732,19 +9037,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -8755,16 +9062,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -8775,13 +9082,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -8792,20 +9099,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -8816,8 +9123,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -8828,9 +9135,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -8841,8 +9148,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -8853,16 +9160,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -8873,8 +9180,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -8885,10 +9192,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -8899,10 +9206,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -8913,9 +9220,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -8926,11 +9233,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -8941,24 +9248,26 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -8969,23 +9278,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -8996,44 +9305,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -9052,9 +9361,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -9065,9 +9374,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -9078,14 +9387,16 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -9096,11 +9407,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -9111,9 +9422,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -9124,10 +9435,10 @@
       },
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -9138,13 +9449,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -9155,20 +9466,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -9179,8 +9490,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -9191,14 +9502,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -9209,9 +9520,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -9222,7 +9533,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -9233,7 +9544,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -9244,7 +9555,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -9255,10 +9566,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -9277,10 +9588,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -9291,7 +9602,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -9302,8 +9613,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -9314,8 +9625,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -9326,16 +9637,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -9346,11 +9657,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -9361,14 +9672,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -9379,7 +9690,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -9390,8 +9701,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -9402,8 +9713,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -9414,8 +9725,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -9426,8 +9737,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -9438,8 +9749,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -9450,7 +9761,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -9461,17 +9772,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -9482,8 +9793,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -9494,12 +9805,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -9510,8 +9821,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -9522,12 +9833,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -9538,7 +9849,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -9549,17 +9860,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -9570,14 +9881,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -9596,20 +9907,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -9620,17 +9931,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -9641,16 +9952,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -9661,22 +9972,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -9688,14 +10001,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -9703,22 +10016,22 @@
     "UAP,Version=v10.0/win10-x86-aot": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -9729,185 +10042,189 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
-          "runtimes/aot/lib/netcore50/mscorlib.dll": {},
           "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "runtimes/aot/lib/netcore50/System.Core.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
           "runtimes/aot/lib/netcore50/System.Net.dll": {},
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {}
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
+          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.Native": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.Native/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         }
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -9918,8 +10235,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -9930,10 +10247,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -9944,11 +10261,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -9959,15 +10276,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -9978,14 +10295,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -9996,12 +10313,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -10012,13 +10329,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -10029,7 +10346,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -10040,17 +10357,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -10061,10 +10378,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -10075,15 +10392,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -10102,7 +10419,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -10113,7 +10430,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -10132,16 +10449,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -10152,18 +10469,18 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -10174,7 +10491,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -10185,8 +10502,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -10197,11 +10514,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -10212,12 +10529,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -10228,15 +10545,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-x86": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -10252,14 +10570,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -10270,21 +10588,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -10295,7 +10613,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -10306,15 +10624,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -10325,13 +10643,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -10342,11 +10660,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -10357,19 +10675,19 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -10380,16 +10698,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -10400,13 +10718,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -10417,20 +10735,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -10441,8 +10759,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -10453,9 +10771,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -10466,8 +10784,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -10478,16 +10796,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -10498,8 +10816,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -10510,10 +10828,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -10524,10 +10842,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -10538,9 +10856,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -10551,11 +10869,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -10566,24 +10884,24 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -10594,23 +10912,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -10621,44 +10939,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -10677,9 +10995,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -10690,9 +11008,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -10703,14 +11021,14 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -10721,11 +11039,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -10736,9 +11054,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -10749,13 +11067,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -10766,20 +11084,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -10790,8 +11108,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -10802,14 +11120,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -10820,9 +11138,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -10833,7 +11151,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -10844,7 +11162,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -10855,7 +11173,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -10866,10 +11184,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -10888,10 +11206,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -10902,7 +11220,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -10913,8 +11231,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -10925,8 +11243,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -10937,16 +11255,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -10957,11 +11275,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -10972,14 +11290,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -10990,7 +11308,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -11001,8 +11319,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -11013,8 +11331,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -11025,8 +11343,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -11037,8 +11355,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -11049,8 +11367,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -11061,7 +11379,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -11072,17 +11390,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -11093,8 +11411,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -11105,12 +11423,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -11121,8 +11439,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -11133,12 +11451,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -11149,7 +11467,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -11160,17 +11478,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -11181,14 +11499,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -11207,20 +11525,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -11231,17 +11549,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -11252,16 +11570,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -11272,22 +11590,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -11299,14 +11619,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -11317,11 +11637,12 @@
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "Package",
       "files": [
+        "Microsoft.CSharp.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/Microsoft.CSharp.dll",
         "lib/net45/_._",
         "lib/netcore50/Microsoft.CSharp.dll",
         "lib/win8/_._",
@@ -11329,21 +11650,20 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.CSharp.nuspec",
         "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/de/Microsoft.CSharp.xml",
         "ref/dotnet/es/Microsoft.CSharp.xml",
         "ref/dotnet/fr/Microsoft.CSharp.xml",
         "ref/dotnet/it/Microsoft.CSharp.xml",
         "ref/dotnet/ja/Microsoft.CSharp.xml",
         "ref/dotnet/ko/Microsoft.CSharp.xml",
-        "ref/dotnet/Microsoft.CSharp.dll",
-        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/ru/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/netcore50/Microsoft.CSharp.dll",
         "ref/netcore50/Microsoft.CSharp.xml",
@@ -11358,10 +11678,10 @@
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.nuspec",
         "[Content_Types].xml",
         "_._",
         "_rels/.rels",
-        "Microsoft.NETCore.nuspec",
         "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp"
       ]
     },
@@ -11369,9 +11689,9 @@
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Platforms.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Platforms.nuspec",
         "package/services/metadata/core-properties/36b51d4c6b524527902ff1a182a64e42.psmdcp",
         "runtime.json"
       ]
@@ -11380,90 +11700,90 @@
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Portable.Compatibility.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
-        "lib/dnxcore50/System.dll",
         "lib/dnxcore50/System.Net.dll",
         "lib/dnxcore50/System.Numerics.dll",
         "lib/dnxcore50/System.Runtime.Serialization.dll",
-        "lib/dnxcore50/System.ServiceModel.dll",
         "lib/dnxcore50/System.ServiceModel.Web.dll",
+        "lib/dnxcore50/System.ServiceModel.dll",
         "lib/dnxcore50/System.Windows.dll",
-        "lib/dnxcore50/System.Xml.dll",
         "lib/dnxcore50/System.Xml.Linq.dll",
         "lib/dnxcore50/System.Xml.Serialization.dll",
+        "lib/dnxcore50/System.Xml.dll",
+        "lib/dnxcore50/System.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/netcore50/System.Core.dll",
-        "lib/netcore50/System.dll",
         "lib/netcore50/System.Net.dll",
         "lib/netcore50/System.Numerics.dll",
         "lib/netcore50/System.Runtime.Serialization.dll",
-        "lib/netcore50/System.ServiceModel.dll",
         "lib/netcore50/System.ServiceModel.Web.dll",
+        "lib/netcore50/System.ServiceModel.dll",
         "lib/netcore50/System.Windows.dll",
-        "lib/netcore50/System.Xml.dll",
         "lib/netcore50/System.Xml.Linq.dll",
         "lib/netcore50/System.Xml.Serialization.dll",
+        "lib/netcore50/System.Xml.dll",
+        "lib/netcore50/System.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
         "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
-        "ref/dotnet/mscorlib.dll",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
-        "ref/dotnet/System.dll",
         "ref/dotnet/System.Net.dll",
         "ref/dotnet/System.Numerics.dll",
         "ref/dotnet/System.Runtime.Serialization.dll",
-        "ref/dotnet/System.ServiceModel.dll",
         "ref/dotnet/System.ServiceModel.Web.dll",
+        "ref/dotnet/System.ServiceModel.dll",
         "ref/dotnet/System.Windows.dll",
-        "ref/dotnet/System.Xml.dll",
         "ref/dotnet/System.Xml.Linq.dll",
         "ref/dotnet/System.Xml.Serialization.dll",
+        "ref/dotnet/System.Xml.dll",
+        "ref/dotnet/System.dll",
+        "ref/dotnet/mscorlib.dll",
         "ref/net45/_._",
-        "ref/netcore50/mscorlib.dll",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
-        "ref/netcore50/System.dll",
         "ref/netcore50/System.Net.dll",
         "ref/netcore50/System.Numerics.dll",
         "ref/netcore50/System.Runtime.Serialization.dll",
-        "ref/netcore50/System.ServiceModel.dll",
         "ref/netcore50/System.ServiceModel.Web.dll",
+        "ref/netcore50/System.ServiceModel.dll",
         "ref/netcore50/System.Windows.dll",
-        "ref/netcore50/System.Xml.dll",
         "ref/netcore50/System.Xml.Linq.dll",
         "ref/netcore50/System.Xml.Serialization.dll",
+        "ref/netcore50/System.Xml.dll",
+        "ref/netcore50/System.dll",
+        "ref/netcore50/mscorlib.dll",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/aot/lib/netcore50/mscorlib.dll",
         "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
         "runtimes/aot/lib/netcore50/System.Core.dll",
-        "runtimes/aot/lib/netcore50/System.dll",
         "runtimes/aot/lib/netcore50/System.Net.dll",
         "runtimes/aot/lib/netcore50/System.Numerics.dll",
         "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
         "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
         "runtimes/aot/lib/netcore50/System.Windows.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.dll",
         "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll"
+        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.dll",
+        "runtimes/aot/lib/netcore50/System.dll",
+        "runtimes/aot/lib/netcore50/mscorlib.dll"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.nuspec",
         "package/services/metadata/core-properties/f289de2ffef9428684eca0c193bc8765.psmdcp",
         "runtime.json"
       ]
@@ -11472,9 +11792,9 @@
       "sha512": "hoJfIl981eXwn9Tz8onO/J1xaYApIfp/YrhjSh9rRhml1U5Wj80LBgyp/6n+KI3VlvcAraThhnHnCTp+M3Uh+w==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR-arm.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.CoreCLR-arm.nuspec",
         "package/services/metadata/core-properties/c1cbeaed81514106b6b7971ac193f132.psmdcp",
         "ref/dotnet/_._",
         "runtimes/win8-arm/lib/dotnet/mscorlib.ni.dll",
@@ -11491,9 +11811,9 @@
       "sha512": "DaY5Z13xCZpnVIGluC5sCo4/0wy1rl6mptBH7v3RYi3guAmG88aSeFoQzyZepo0H0jEixUxNFM0+MB6Jc+j0bw==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR-x64.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.CoreCLR-x64.nuspec",
         "package/services/metadata/core-properties/bd7bd26b6b8242179b5b8ca3d9ffeb95.psmdcp",
         "ref/dotnet/_._",
         "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
@@ -11510,9 +11830,9 @@
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
         "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
         "ref/dotnet/_._",
         "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
@@ -11529,10 +11849,10 @@
       "sha512": "tMsWWrH1AJCguiM22zK/vr6COxqz62Q1F02B07IXAUN405R3HGk5SkD/DL0Hte+OTjNtW9LkKXpOggGBRwYFNg==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.Native.nuspec",
         "[Content_Types].xml",
         "_._",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.Native.nuspec",
         "package/services/metadata/core-properties/a985563978b547f984c16150ef73e353.psmdcp"
       ]
     },
@@ -11540,9 +11860,9 @@
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Targets.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Targets.nuspec",
         "package/services/metadata/core-properties/5413a5ed3fde4121a1c9ee8feb12ba66.psmdcp",
         "runtime.json"
       ]
@@ -11551,9 +11871,9 @@
       "sha512": "jszcJ6okLlhqF4OQbhSbixLOuLUyVT3BP7Y7/i7fcDMwnHBd1Pmdz6M1Al9SMDKVLA2oSaItg4tq6C0ydv8lYQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.nuspec",
         "package/services/metadata/core-properties/0d18100c9f8c491492d8ddeaa9581526.psmdcp",
         "runtime.json"
       ]
@@ -11562,10 +11882,10 @@
       "sha512": "D0nsAm+yTk0oSSC7E6PcmuuEewBAQbGgIXNcCnRqQ4qLPdQLMjMHg8cilGs3xZgwTRQmMtEn45TAatrU1otWPQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.UniversalWindowsPlatform.nuspec",
         "[Content_Types].xml",
         "_._",
         "_rels/.rels",
-        "Microsoft.NETCore.UniversalWindowsPlatform.nuspec",
         "package/services/metadata/core-properties/5dffd3ce5b6640febe2db09251387062.psmdcp"
       ]
     },
@@ -11573,15 +11893,31 @@
       "sha512": "NC+dpFMdhujz2sWAdJ8EmBk07p1zOlNi0FCCnZEbzftABpw9xZ99EMP/bUJrPTgCxHfzJAiuLPOtAauzVINk0w==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Windows.ApiSets-x64.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Windows.ApiSets-x64.nuspec",
         "package/services/metadata/core-properties/b25894a2a9234c329a98dc84006b2292.psmdcp",
         "runtimes/win10-x64/native/_._",
         "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -11607,9 +11943,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-localization-l1-2-0.dll",
@@ -11623,7 +11956,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-normalization-l1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-2-0.dll",
@@ -11631,7 +11963,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-2.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-profile-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-psapi-l1-1-0.dll",
@@ -11644,13 +11975,11 @@
         "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -11675,21 +12004,12 @@
         "runtimes/win7-x64/native/api-ms-win-core-wow64-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-xstate-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-base-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-provider-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-sddl-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-service-core-l1-1-0.dll",
@@ -11700,20 +12020,13 @@
         "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
+        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win8-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win8-x64/native/api-ms-win-core-localization-l1-2-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
         "runtimes/win8-x64/native/api-ms-win-core-memory-l1-1-2.dll",
@@ -11722,33 +12035,56 @@
         "runtimes/win8-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
         "runtimes/win8-x64/native/api-ms-win-core-winrt-error-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win8-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll"
+        "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll",
+        "runtimes/win81-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x64/native/api-ms-win-security-cpwl-l1-1-0.dll"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
         "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
         "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -11774,9 +12110,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-localization-l1-2-0.dll",
@@ -11790,7 +12123,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-normalization-l1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-2-0.dll",
@@ -11798,7 +12130,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-profile-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-psapi-l1-1-0.dll",
@@ -11811,13 +12142,11 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -11842,21 +12171,12 @@
         "runtimes/win7-x86/native/api-ms-win-core-wow64-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-xstate-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-base-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-provider-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-sddl-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-service-core-l1-1-0.dll",
@@ -11867,20 +12187,13 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
+        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win8-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-localization-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-memory-l1-1-2.dll",
@@ -11889,24 +12202,32 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
         "runtimes/win8-x86/native/api-ms-win-core-winrt-error-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win8-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "Package",
       "files": [
+        "Microsoft.VisualBasic.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/Microsoft.VisualBasic.dll",
@@ -11914,16 +12235,15 @@
         "lib/netcore50/Microsoft.VisualBasic.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "Microsoft.VisualBasic.nuspec",
         "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
         "ref/dotnet/es/Microsoft.VisualBasic.xml",
         "ref/dotnet/fr/Microsoft.VisualBasic.xml",
         "ref/dotnet/it/Microsoft.VisualBasic.xml",
         "ref/dotnet/ja/Microsoft.VisualBasic.xml",
         "ref/dotnet/ko/Microsoft.VisualBasic.xml",
-        "ref/dotnet/Microsoft.VisualBasic.dll",
-        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/ru/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
@@ -11938,29 +12258,29 @@
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "Package",
       "files": [
+        "Microsoft.Win32.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/Microsoft.Win32.Primitives.dll",
         "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.Win32.Primitives.nuspec",
         "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/Microsoft.Win32.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._"
@@ -11970,6 +12290,7 @@
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "Package",
       "files": [
+        "System.AppContext.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.AppContext.dll",
@@ -11980,6 +12301,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/de/System.AppContext.xml",
         "ref/dotnet/es/System.AppContext.xml",
         "ref/dotnet/fr/System.AppContext.xml",
@@ -11987,22 +12312,18 @@
         "ref/dotnet/ja/System.AppContext.xml",
         "ref/dotnet/ko/System.AppContext.xml",
         "ref/dotnet/ru/System.AppContext.xml",
-        "ref/dotnet/System.AppContext.dll",
-        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/zh-hans/System.AppContext.xml",
         "ref/dotnet/zh-hant/System.AppContext.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.AppContext.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "Package",
       "files": [
+        "System.Collections.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Collections.dll",
@@ -12013,6 +12334,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/de/System.Collections.xml",
         "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
@@ -12020,32 +12345,32 @@
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
         "ref/dotnet/zh-hant/System.Collections.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
-        "System.Collections.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "Package",
       "files": [
+        "System.Collections.Concurrent.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
         "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
@@ -12053,45 +12378,45 @@
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.Concurrent.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
       "files": [
+        "System.Collections.Immutable.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
-        "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
-        "System.Collections.Immutable.nuspec"
+        "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "Package",
       "files": [
+        "System.Collections.NonGeneric.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Collections.NonGeneric.dll",
         "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
         "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
@@ -12099,31 +12424,31 @@
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.NonGeneric.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Collections.Specialized/4.0.0": {
       "sha512": "poJFwQCUOoXqvdoGxx+3p8Z63yawcYKPBSFP67Z2jICeOINvEIQZN7mVOAnC7gsVF0WU+A2wtVwfhagC7UCgAg==",
       "type": "Package",
       "files": [
+        "System.Collections.Specialized.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Collections.Specialized.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Collections.Specialized.dll",
         "lib/net46/System.Collections.Specialized.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/e7002e4ccd044c00a7cbd4a37efe3400.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.Specialized.dll",
+        "ref/dotnet/System.Collections.Specialized.xml",
         "ref/dotnet/de/System.Collections.Specialized.xml",
         "ref/dotnet/es/System.Collections.Specialized.xml",
         "ref/dotnet/fr/System.Collections.Specialized.xml",
@@ -12131,22 +12456,18 @@
         "ref/dotnet/ja/System.Collections.Specialized.xml",
         "ref/dotnet/ko/System.Collections.Specialized.xml",
         "ref/dotnet/ru/System.Collections.Specialized.xml",
-        "ref/dotnet/System.Collections.Specialized.dll",
-        "ref/dotnet/System.Collections.Specialized.xml",
         "ref/dotnet/zh-hans/System.Collections.Specialized.xml",
         "ref/dotnet/zh-hant/System.Collections.Specialized.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.Specialized.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "Package",
       "files": [
+        "System.ComponentModel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.ComponentModel.dll",
@@ -12156,6 +12477,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/de/System.ComponentModel.xml",
         "ref/dotnet/es/System.ComponentModel.xml",
         "ref/dotnet/fr/System.ComponentModel.xml",
@@ -12163,8 +12486,6 @@
         "ref/dotnet/ja/System.ComponentModel.xml",
         "ref/dotnet/ko/System.ComponentModel.xml",
         "ref/dotnet/ru/System.ComponentModel.xml",
-        "ref/dotnet/System.ComponentModel.dll",
-        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.xml",
         "ref/dotnet/zh-hant/System.ComponentModel.xml",
         "ref/net45/_._",
@@ -12172,23 +12493,27 @@
         "ref/netcore50/System.ComponentModel.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.ComponentModel.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "Package",
       "files": [
+        "System.ComponentModel.Annotations.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/de/System.ComponentModel.Annotations.xml",
         "ref/dotnet/es/System.ComponentModel.Annotations.xml",
         "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
@@ -12196,31 +12521,31 @@
         "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/System.ComponentModel.Annotations.dll",
-        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ComponentModel.Annotations.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "Package",
       "files": [
+        "System.ComponentModel.EventBasedAsync.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
@@ -12228,31 +12553,31 @@
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ComponentModel.EventBasedAsync.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Data.Common/4.0.0": {
       "sha512": "SA7IdoTWiImVr0exDM68r0mKmR4f/qFGxZUrJQKu4YS7F+3afWzSOCezHxWdevQ0ONi4WRQsOiv+Zf9p8H0Feg==",
       "type": "Package",
       "files": [
+        "System.Data.Common.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Data.Common.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Data.Common.dll",
         "lib/net46/System.Data.Common.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/aa5ad20c33d94c8e8016ba4fc64d8d66.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Data.Common.dll",
+        "ref/dotnet/System.Data.Common.xml",
         "ref/dotnet/de/System.Data.Common.xml",
         "ref/dotnet/es/System.Data.Common.xml",
         "ref/dotnet/fr/System.Data.Common.xml",
@@ -12260,22 +12585,18 @@
         "ref/dotnet/ja/System.Data.Common.xml",
         "ref/dotnet/ko/System.Data.Common.xml",
         "ref/dotnet/ru/System.Data.Common.xml",
-        "ref/dotnet/System.Data.Common.dll",
-        "ref/dotnet/System.Data.Common.xml",
         "ref/dotnet/zh-hans/System.Data.Common.xml",
         "ref/dotnet/zh-hant/System.Data.Common.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Data.Common.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Data.Common.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Contracts.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
@@ -12285,6 +12606,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
         "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
@@ -12292,8 +12615,6 @@
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
@@ -12302,14 +12623,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
-        "System.Diagnostics.Contracts.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Debug.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
@@ -12320,6 +12641,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
         "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
@@ -12327,23 +12652,19 @@
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
-        "System.Diagnostics.Debug.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.StackTrace.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
@@ -12354,6 +12675,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/de/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/fr/System.Diagnostics.StackTrace.xml",
@@ -12361,23 +12686,19 @@
         "ref/dotnet/ja/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ko/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ru/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "System.Diagnostics.StackTrace.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Tools.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
@@ -12387,6 +12708,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
         "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
@@ -12394,8 +12717,6 @@
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
@@ -12404,14 +12725,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
-        "System.Diagnostics.Tools.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Tracing.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
@@ -12422,6 +12743,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
         "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
@@ -12429,23 +12754,19 @@
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
-        "System.Diagnostics.Tracing.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "Package",
       "files": [
+        "System.Dynamic.Runtime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
@@ -12456,6 +12777,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/de/System.Dynamic.Runtime.xml",
         "ref/dotnet/es/System.Dynamic.Runtime.xml",
         "ref/dotnet/fr/System.Dynamic.Runtime.xml",
@@ -12463,24 +12788,20 @@
         "ref/dotnet/ja/System.Dynamic.Runtime.xml",
         "ref/dotnet/ko/System.Dynamic.Runtime.xml",
         "ref/dotnet/ru/System.Dynamic.Runtime.xml",
-        "ref/dotnet/System.Dynamic.Runtime.dll",
-        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
-        "System.Dynamic.Runtime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "Package",
       "files": [
+        "System.Globalization.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Globalization.dll",
@@ -12491,6 +12812,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/de/System.Globalization.xml",
         "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
@@ -12498,23 +12823,19 @@
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
         "ref/dotnet/zh-hant/System.Globalization.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
-        "System.Globalization.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "Package",
       "files": [
+        "System.Globalization.Calendars.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
@@ -12525,6 +12846,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
         "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
@@ -12532,32 +12857,32 @@
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "System.Globalization.Calendars.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "Package",
       "files": [
+        "System.Globalization.Extensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Globalization.Extensions.dll",
         "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
         "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
@@ -12565,22 +12890,18 @@
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Globalization.Extensions.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "Package",
       "files": [
+        "System.IO.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.IO.dll",
@@ -12591,6 +12912,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/de/System.IO.xml",
         "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
@@ -12598,28 +12923,24 @@
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
         "ref/dotnet/zh-hant/System.IO.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
-        "System.IO.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.IO.Compression.dll",
         "lib/net45/_._",
         "lib/netcore50/System.IO.Compression.dll",
         "lib/win8/_._",
@@ -12627,6 +12948,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/de/System.IO.Compression.xml",
         "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
@@ -12634,12 +12959,8 @@
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
         "ref/dotnet/zh-hant/System.IO.Compression.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/netcore50/System.IO.Compression.dll",
         "ref/netcore50/System.IO.Compression.xml",
@@ -12647,59 +12968,63 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.IO.Compression.nuspec"
+        "runtime.json"
       ]
     },
     "System.IO.Compression.clrcompression-arm/4.0.0": {
       "sha512": "Kk21GecAbI+H6tMP6/lMssGObbhoHwLiREiB5UkNMCypdxACuF+6gmrdDTousCUcbH28CJeo7tArrnUc+bchuw==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.clrcompression-arm.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "package/services/metadata/core-properties/e09228dcfd7b47adb2ddcf73e2eb6ddf.psmdcp",
         "runtimes/win10-arm/native/ClrCompression.dll",
-        "runtimes/win7-arm/native/clrcompression.dll",
-        "System.IO.Compression.clrcompression-arm.nuspec"
+        "runtimes/win7-arm/native/clrcompression.dll"
       ]
     },
     "System.IO.Compression.clrcompression-x64/4.0.0": {
       "sha512": "Lqr+URMwKzf+8HJF6YrqEqzKzDzFJTE4OekaxqdIns71r8Ufbd8SbZa0LKl9q+7nu6Em4SkIEXVMB7plSXekOw==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.clrcompression-x64.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "package/services/metadata/core-properties/416c3fd9fab749d484e0fed458de199f.psmdcp",
         "runtimes/win10-x64/native/ClrCompression.dll",
-        "runtimes/win7-x64/native/clrcompression.dll",
-        "System.IO.Compression.clrcompression-x64.nuspec"
+        "runtimes/win7-x64/native/clrcompression.dll"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.clrcompression-x86.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "package/services/metadata/core-properties/cd12f86c8cc2449589dfbe349763f7b3.psmdcp",
         "runtimes/win10-x86/native/ClrCompression.dll",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "System.IO.Compression.clrcompression-x86.nuspec"
+        "runtimes/win7-x86/native/clrcompression.dll"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.ZipFile.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.IO.Compression.ZipFile.dll",
         "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
@@ -12707,22 +13032,18 @@
         "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.Compression.ZipFile.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "Package",
       "files": [
+        "System.IO.FileSystem.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.IO.FileSystem.dll",
@@ -12733,6 +13054,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/de/System.IO.FileSystem.xml",
         "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
@@ -12740,31 +13065,31 @@
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.FileSystem.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "Package",
       "files": [
+        "System.IO.FileSystem.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
         "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
@@ -12772,22 +13097,18 @@
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.FileSystem.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO.IsolatedStorage/4.0.0": {
       "sha512": "d5KimUbZ49Ki6A/uwU+Iodng+nhJvpRs7hr/828cfeXC02LxUiggnRnAu+COtWcKvJ2YbBmAGOcO4GLK4fX1+w==",
       "type": "Package",
       "files": [
+        "System.IO.IsolatedStorage.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/MonoAndroid10/_._",
@@ -12796,6 +13117,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/0d69e649eab84c3cad77d63bb460f7e7.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.IsolatedStorage.dll",
+        "ref/dotnet/System.IO.IsolatedStorage.xml",
         "ref/dotnet/de/System.IO.IsolatedStorage.xml",
         "ref/dotnet/es/System.IO.IsolatedStorage.xml",
         "ref/dotnet/fr/System.IO.IsolatedStorage.xml",
@@ -12803,30 +13128,30 @@
         "ref/dotnet/ja/System.IO.IsolatedStorage.xml",
         "ref/dotnet/ko/System.IO.IsolatedStorage.xml",
         "ref/dotnet/ru/System.IO.IsolatedStorage.xml",
-        "ref/dotnet/System.IO.IsolatedStorage.dll",
-        "ref/dotnet/System.IO.IsolatedStorage.xml",
         "ref/dotnet/zh-hans/System.IO.IsolatedStorage.xml",
         "ref/dotnet/zh-hant/System.IO.IsolatedStorage.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.IsolatedStorage.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "Package",
       "files": [
+        "System.IO.UnmanagedMemoryStream.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
         "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
@@ -12834,22 +13159,18 @@
         "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.UnmanagedMemoryStream.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
       "files": [
+        "System.Linq.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Linq.dll",
@@ -12859,6 +13180,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/de/System.Linq.xml",
         "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
@@ -12866,8 +13189,6 @@
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
         "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
@@ -12875,14 +13196,14 @@
         "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Linq.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "Package",
       "files": [
+        "System.Linq.Expressions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Linq.Expressions.dll",
@@ -12893,6 +13214,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/de/System.Linq.Expressions.xml",
         "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
@@ -12900,24 +13225,20 @@
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
-        "System.Linq.Expressions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "Package",
       "files": [
+        "System.Linq.Parallel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Linq.Parallel.dll",
@@ -12926,6 +13247,8 @@
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/de/System.Linq.Parallel.xml",
         "ref/dotnet/es/System.Linq.Parallel.xml",
         "ref/dotnet/fr/System.Linq.Parallel.xml",
@@ -12933,22 +13256,20 @@
         "ref/dotnet/ja/System.Linq.Parallel.xml",
         "ref/dotnet/ko/System.Linq.Parallel.xml",
         "ref/dotnet/ru/System.Linq.Parallel.xml",
-        "ref/dotnet/System.Linq.Parallel.dll",
-        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Linq.Parallel.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "Package",
       "files": [
+        "System.Linq.Queryable.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Linq.Queryable.dll",
@@ -12958,6 +13279,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/de/System.Linq.Queryable.xml",
         "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
@@ -12965,8 +13288,6 @@
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
@@ -12974,14 +13295,14 @@
         "ref/netcore50/System.Linq.Queryable.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Linq.Queryable.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "Package",
       "files": [
+        "System.Net.Http.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Net.Http.dll",
@@ -12990,6 +13311,8 @@
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/de/System.Net.Http.xml",
         "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
@@ -12997,27 +13320,27 @@
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
         "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Net.Http.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Net.Http.Rtc/4.0.0": {
       "sha512": "PlE+oJgXdbxPmZYR6GBywRkyIPovjB1Y0SYHizj2Iflgu80uJQC4szl9gue4rKI2FgXiEbj9JL7wL5K3mp9HAQ==",
       "type": "Package",
       "files": [
+        "System.Net.Http.Rtc.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/netcore50/System.Net.Http.Rtc.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/5ae6b04142264f2abb319c7dccbfb69f.psmdcp",
+        "ref/dotnet/System.Net.Http.Rtc.dll",
+        "ref/dotnet/System.Net.Http.Rtc.xml",
         "ref/dotnet/de/System.Net.Http.Rtc.xml",
         "ref/dotnet/es/System.Net.Http.Rtc.xml",
         "ref/dotnet/fr/System.Net.Http.Rtc.xml",
@@ -13025,20 +13348,18 @@
         "ref/dotnet/ja/System.Net.Http.Rtc.xml",
         "ref/dotnet/ko/System.Net.Http.Rtc.xml",
         "ref/dotnet/ru/System.Net.Http.Rtc.xml",
-        "ref/dotnet/System.Net.Http.Rtc.dll",
-        "ref/dotnet/System.Net.Http.Rtc.xml",
         "ref/dotnet/zh-hans/System.Net.Http.Rtc.xml",
         "ref/dotnet/zh-hant/System.Net.Http.Rtc.xml",
         "ref/netcore50/System.Net.Http.Rtc.dll",
         "ref/netcore50/System.Net.Http.Rtc.xml",
-        "ref/win8/_._",
-        "System.Net.Http.Rtc.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "Package",
       "files": [
+        "System.Net.NetworkInformation.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/MonoAndroid10/_._",
@@ -13051,6 +13372,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
         "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
@@ -13058,12 +13383,8 @@
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/netcore50/System.Net.NetworkInformation.dll",
         "ref/netcore50/System.Net.NetworkInformation.xml",
@@ -13071,14 +13392,14 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.NetworkInformation.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "Package",
       "files": [
+        "System.Net.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Net.Primitives.dll",
@@ -13089,6 +13410,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/de/System.Net.Primitives.xml",
         "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
@@ -13096,31 +13421,31 @@
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
         "ref/dotnet/zh-hant/System.Net.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Net.Requests/4.0.10": {
       "sha512": "A6XBR7TztiIQg6hx7VGfbBKmRTAavUERm2E7pmNz/gZeGvwyP0lcKHZxylJtNVKj7DPwr91bD87oLY6zZYntcg==",
       "type": "Package",
       "files": [
+        "System.Net.Requests.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Net.Requests.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Net.Requests.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/7a4e397882e44db3aa06d6d8c9dd3d66.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.Requests.dll",
+        "ref/dotnet/System.Net.Requests.xml",
         "ref/dotnet/de/System.Net.Requests.xml",
         "ref/dotnet/es/System.Net.Requests.xml",
         "ref/dotnet/fr/System.Net.Requests.xml",
@@ -13128,22 +13453,18 @@
         "ref/dotnet/ja/System.Net.Requests.xml",
         "ref/dotnet/ko/System.Net.Requests.xml",
         "ref/dotnet/ru/System.Net.Requests.xml",
-        "ref/dotnet/System.Net.Requests.dll",
-        "ref/dotnet/System.Net.Requests.xml",
         "ref/dotnet/zh-hans/System.Net.Requests.xml",
         "ref/dotnet/zh-hant/System.Net.Requests.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Requests.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Net.Sockets/4.0.0": {
       "sha512": "7bBNLdO6Xw0BGyFVSxjloGXMvsc3qQmW+70bYMLwHEAVivMK8zx+E7XO8CeJnAko2mFj6R402E798EGYUksFcQ==",
       "type": "Package",
       "files": [
+        "System.Net.Sockets.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/MonoAndroid10/_._",
@@ -13153,6 +13474,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/cca33bc0996f49c68976fa5bab1500ff.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.Sockets.dll",
+        "ref/dotnet/System.Net.Sockets.xml",
         "ref/dotnet/de/System.Net.Sockets.xml",
         "ref/dotnet/es/System.Net.Sockets.xml",
         "ref/dotnet/fr/System.Net.Sockets.xml",
@@ -13160,31 +13485,31 @@
         "ref/dotnet/ja/System.Net.Sockets.xml",
         "ref/dotnet/ko/System.Net.Sockets.xml",
         "ref/dotnet/ru/System.Net.Sockets.xml",
-        "ref/dotnet/System.Net.Sockets.dll",
-        "ref/dotnet/System.Net.Sockets.xml",
         "ref/dotnet/zh-hans/System.Net.Sockets.xml",
         "ref/dotnet/zh-hant/System.Net.Sockets.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Sockets.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Sockets.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Net.WebHeaderCollection/4.0.0": {
       "sha512": "IsIZAsHm/yK7R/XASnEc4EMffFLIMgYchG3/zJv6B4LwMnXZwrVlSPpNbPgEVb0lSXyztsn7A6sIPAACQQ2vTQ==",
       "type": "Package",
       "files": [
+        "System.Net.WebHeaderCollection.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Net.WebHeaderCollection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Net.WebHeaderCollection.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/7ab0d7bde19b47548622bfa222a4eccb.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.WebHeaderCollection.dll",
+        "ref/dotnet/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/de/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/es/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/fr/System.Net.WebHeaderCollection.xml",
@@ -13192,64 +13517,64 @@
         "ref/dotnet/ja/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/ko/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/ru/System.Net.WebHeaderCollection.xml",
-        "ref/dotnet/System.Net.WebHeaderCollection.dll",
-        "ref/dotnet/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/zh-hans/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/zh-hant/System.Net.WebHeaderCollection.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.WebHeaderCollection.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "Package",
       "files": [
+        "System.Numerics.Vectors.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Numerics.Vectors.dll",
         "lib/net46/System.Numerics.Vectors.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
-        "ref/dotnet/System.Numerics.Vectors.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Numerics.Vectors.dll",
         "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Numerics.Vectors.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
       "sha512": "Ly7GvoPFZq6GyfZpfS0E7uCk1cinl5BANAngXVuau3lD2QqZJMHitzlPv6n1FlIn6krfv99X2IPkIaVzUwDHXA==",
       "type": "Package",
       "files": [
+        "System.Numerics.Vectors.WindowsRuntime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll",
-        "package/services/metadata/core-properties/6db0e2464a274e8eb688cd193eb37876.psmdcp",
-        "System.Numerics.Vectors.WindowsRuntime.nuspec"
+        "package/services/metadata/core-properties/6db0e2464a274e8eb688cd193eb37876.psmdcp"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "Package",
       "files": [
+        "System.ObjectModel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.ObjectModel.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/de/System.ObjectModel.xml",
         "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
@@ -13257,22 +13582,18 @@
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
         "ref/dotnet/zh-hant/System.ObjectModel.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ObjectModel.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Private.DataContractSerialization/4.0.0": {
       "sha512": "uQvzoXHXHn/9YqUmPtgD8ZPJIlBuuL3QHegbuik97W/umoI28fOnGLnvjRHhju1VMWvFLRQoh7uZkBaoZ+KpVQ==",
       "type": "Package",
       "files": [
+        "System.Private.DataContractSerialization.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Private.DataContractSerialization.dll",
@@ -13281,42 +13602,42 @@
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
-        "System.Private.DataContractSerialization.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "Package",
       "files": [
+        "System.Private.Networking.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._",
-        "System.Private.Networking.nuspec"
+        "ref/netcore50/_._"
       ]
     },
     "System.Private.ServiceModel/4.0.0": {
       "sha512": "cm2wEa1f9kuUq/2k8uIwepgZJi5HdxXSnjGQIeXmAb7RaWfZPEC/iamv9GJ67b5LPnCZHR0KvtFqh82e8AAYSw==",
       "type": "Package",
       "files": [
+        "System.Private.ServiceModel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "package/services/metadata/core-properties/5668af7c10764fafb51182a583dfb872.psmdcp",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._",
-        "System.Private.ServiceModel.nuspec"
+        "ref/netcore50/_._"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "Package",
       "files": [
+        "System.Private.Uri.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Private.Uri.dll",
@@ -13324,14 +13645,14 @@
         "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "System.Private.Uri.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "Package",
       "files": [
+        "System.Reflection.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.dll",
@@ -13342,6 +13663,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/de/System.Reflection.xml",
         "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
@@ -13349,29 +13674,27 @@
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
         "ref/dotnet/zh-hant/System.Reflection.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
-        "System.Reflection.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
       ]
     },
     "System.Reflection.Context/4.0.0": {
       "sha512": "Gz4sUHHFd/52RjHccSHbOXdujJEWKfL3gIaA+ekxvQaQfJGbI2tPzA0Uv3WTCTDRGHgtoNq5WS9E007Dt4P/VQ==",
       "type": "Package",
       "files": [
+        "System.Reflection.Context.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Context.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/263ca61f1b594d9395e210a55a8fe7a7.psmdcp",
+        "ref/dotnet/System.Reflection.Context.dll",
+        "ref/dotnet/System.Reflection.Context.xml",
         "ref/dotnet/de/System.Reflection.Context.xml",
         "ref/dotnet/es/System.Reflection.Context.xml",
         "ref/dotnet/fr/System.Reflection.Context.xml",
@@ -13379,21 +13702,19 @@
         "ref/dotnet/ja/System.Reflection.Context.xml",
         "ref/dotnet/ko/System.Reflection.Context.xml",
         "ref/dotnet/ru/System.Reflection.Context.xml",
-        "ref/dotnet/System.Reflection.Context.dll",
-        "ref/dotnet/System.Reflection.Context.xml",
         "ref/dotnet/zh-hans/System.Reflection.Context.xml",
         "ref/dotnet/zh-hant/System.Reflection.Context.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Reflection.Context.dll",
         "ref/netcore50/System.Reflection.Context.xml",
-        "ref/win8/_._",
-        "System.Reflection.Context.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "Package",
       "files": [
+        "System.Reflection.DispatchProxy.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
@@ -13404,6 +13725,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
@@ -13411,23 +13736,19 @@
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
-        "System.Reflection.DispatchProxy.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "Package",
       "files": [
+        "System.Reflection.Emit.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Emit.dll",
@@ -13436,6 +13757,9 @@
         "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/de/System.Reflection.Emit.xml",
         "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
@@ -13443,20 +13767,17 @@
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
-        "ref/MonoAndroid10/_._",
         "ref/net45/_._",
-        "ref/xamarinmac20/_._",
-        "System.Reflection.Emit.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "Package",
       "files": [
+        "System.Reflection.Emit.ILGeneration.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
@@ -13464,6 +13785,8 @@
         "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
         "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
@@ -13471,19 +13794,17 @@
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
-        "ref/wp80/_._",
-        "System.Reflection.Emit.ILGeneration.nuspec"
+        "ref/wp80/_._"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "Package",
       "files": [
+        "System.Reflection.Emit.Lightweight.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
@@ -13491,6 +13812,8 @@
         "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/wp80/_._",
         "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
@@ -13498,19 +13821,17 @@
         "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
-        "ref/wp80/_._",
-        "System.Reflection.Emit.Lightweight.nuspec"
+        "ref/wp80/_._"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "Package",
       "files": [
+        "System.Reflection.Extensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
@@ -13520,6 +13841,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
         "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
@@ -13527,8 +13850,6 @@
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
@@ -13537,28 +13858,28 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
-        "System.Reflection.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
       ]
     },
     "System.Reflection.Metadata/1.0.22": {
       "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
       "type": "Package",
       "files": [
+        "System.Reflection.Metadata.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Reflection.Metadata.dll",
         "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
-        "System.Reflection.Metadata.nuspec"
+        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "Package",
       "files": [
+        "System.Reflection.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
@@ -13568,6 +13889,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
         "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
@@ -13575,8 +13898,6 @@
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
@@ -13585,14 +13906,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
-        "System.Reflection.Primitives.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "Package",
       "files": [
+        "System.Reflection.TypeExtensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
@@ -13603,6 +13924,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
@@ -13610,23 +13935,19 @@
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "System.Reflection.TypeExtensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "Package",
       "files": [
+        "System.Resources.ResourceManager.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
@@ -13636,6 +13957,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
         "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
@@ -13643,8 +13966,6 @@
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
@@ -13653,14 +13974,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
-        "System.Resources.ResourceManager.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "Package",
       "files": [
+        "System.Runtime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.dll",
@@ -13671,6 +13992,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/de/System.Runtime.xml",
         "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
@@ -13678,23 +14003,19 @@
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
         "ref/dotnet/zh-hant/System.Runtime.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "Package",
       "files": [
+        "System.Runtime.Extensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
@@ -13705,6 +14026,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
         "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
@@ -13712,23 +14037,19 @@
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
-        "System.Runtime.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "Package",
       "files": [
+        "System.Runtime.Handles.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Handles.dll",
@@ -13739,6 +14060,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/de/System.Runtime.Handles.xml",
         "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
@@ -13746,23 +14071,19 @@
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
-        "System.Runtime.Handles.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "Package",
       "files": [
+        "System.Runtime.InteropServices.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
@@ -13773,6 +14094,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
         "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
@@ -13780,23 +14105,19 @@
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
-        "System.Runtime.InteropServices.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
       ]
     },
     "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
       "sha512": "K5MGSvw/sGPKQYdOVqSpsVbHBE8HccHIDEhUNjM1lui65KGF/slNZfijGU87ggQiVXTI802ebKiOYBkwiLotow==",
       "type": "Package",
       "files": [
+        "System.Runtime.InteropServices.WindowsRuntime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/net45/_._",
@@ -13805,6 +14126,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/3c944c6b4d6044d28ee80e49a09300c9.psmdcp",
+        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/de/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/es/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.WindowsRuntime.xml",
@@ -13812,8 +14135,6 @@
         "ref/dotnet/ja/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.WindowsRuntime.xml",
-        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.dll",
-        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/zh-hant/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/net45/_._",
@@ -13822,14 +14143,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
-        "System.Runtime.InteropServices.WindowsRuntime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "Package",
       "files": [
+        "System.Runtime.Numerics.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Runtime.Numerics.dll",
@@ -13838,6 +14159,8 @@
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
         "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
@@ -13845,22 +14168,20 @@
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Runtime.Numerics.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Runtime.Serialization.Json/4.0.0": {
       "sha512": "emhWMQP3sdtkAhD0TOeP3FfjS57sfQMQ2sqA6f2Yj5Gd9jkHV4KsQ2TsoJjghca6d8fur7+REQ6ILBXVdGf/0g==",
       "type": "Package",
       "files": [
+        "System.Runtime.Serialization.Json.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Serialization.Json.dll",
@@ -13870,6 +14191,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/2c520ff333ad4bde986eb7a015ba6343.psmdcp",
+        "ref/dotnet/System.Runtime.Serialization.Json.dll",
+        "ref/dotnet/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/de/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/es/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/fr/System.Runtime.Serialization.Json.xml",
@@ -13877,8 +14200,6 @@
         "ref/dotnet/ja/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/ko/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/ru/System.Runtime.Serialization.Json.xml",
-        "ref/dotnet/System.Runtime.Serialization.Json.dll",
-        "ref/dotnet/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/zh-hans/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Json.xml",
         "ref/net45/_._",
@@ -13887,23 +14208,27 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll",
-        "System.Runtime.Serialization.Json.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll"
       ]
     },
     "System.Runtime.Serialization.Primitives/4.0.10": {
       "sha512": "NPc8DZIomf5tGjYtz/KTHI01IPcVlypfhCux32AbLPDjTotdvL8TpKRwMyQJ6Kh08yprRVH7uBD1PdJiuoFzag==",
       "type": "Package",
       "files": [
+        "System.Runtime.Serialization.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/92e70054da8743d68462736e85fe5580.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/de/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/es/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/fr/System.Runtime.Serialization.Primitives.xml",
@@ -13911,22 +14236,18 @@
         "ref/dotnet/ja/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/ko/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/ru/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
-        "ref/dotnet/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/zh-hans/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Runtime.Serialization.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Runtime.Serialization.Xml/4.0.10": {
       "sha512": "xsy7XbH8RTpKoDPNcibSGCOpujsmwUmOWAby3PssqkZFpLBXUbDO2s6JKITRjxejET2g0PK8t+mdIvu3xmUuKA==",
       "type": "Package",
       "files": [
+        "System.Runtime.Serialization.Xml.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
@@ -13937,6 +14258,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/7d99189e9ae248c9a98d9fc3ccdc5130.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Serialization.Xml.dll",
+        "ref/dotnet/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/de/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/es/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/fr/System.Runtime.Serialization.Xml.xml",
@@ -13944,29 +14269,27 @@
         "ref/dotnet/ja/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/ko/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/ru/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/System.Runtime.Serialization.Xml.dll",
-        "ref/dotnet/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/zh-hans/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Xml.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
-        "System.Runtime.Serialization.Xml.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll"
       ]
     },
     "System.Runtime.WindowsRuntime/4.0.10": {
       "sha512": "9w6ypdnEw8RrLRlxTbLAYrap4eL1xIQeNoOaumQVOQ8TTD/5g9FGrBtY3KLiGxAPieN9AwAAEIDkugU85Cwuvg==",
       "type": "Package",
       "files": [
+        "System.Runtime.WindowsRuntime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/netcore50/System.Runtime.WindowsRuntime.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/a81cabb2b7e843ce801ecf91886941d4.psmdcp",
+        "ref/dotnet/System.Runtime.WindowsRuntime.dll",
+        "ref/dotnet/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/de/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/es/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/fr/System.Runtime.WindowsRuntime.xml",
@@ -13974,28 +14297,28 @@
         "ref/dotnet/ja/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/ko/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/ru/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/System.Runtime.WindowsRuntime.dll",
-        "ref/dotnet/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/zh-hans/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/zh-hant/System.Runtime.WindowsRuntime.xml",
         "ref/netcore50/System.Runtime.WindowsRuntime.dll",
         "ref/netcore50/System.Runtime.WindowsRuntime.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll",
-        "System.Runtime.WindowsRuntime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll"
       ]
     },
     "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
       "sha512": "2GY3fkXBMQOyyO9ovaH46CN6MD2ck/Gvk4VNAgVDvtmfO3HXYFNd+bB05WhVcJrHKbfKZNwfwZKpYZ+OsVFsLw==",
       "type": "Package",
       "files": [
+        "System.Runtime.WindowsRuntime.UI.Xaml.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/0f3b84a81b7a4a97aa765ed058bf6c20.psmdcp",
+        "ref/dotnet/System.Runtime.WindowsRuntime.UI.Xaml.dll",
+        "ref/dotnet/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/de/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/es/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/fr/System.Runtime.WindowsRuntime.UI.Xaml.xml",
@@ -14003,30 +14326,32 @@
         "ref/dotnet/ja/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/ko/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/ru/System.Runtime.WindowsRuntime.UI.Xaml.xml",
-        "ref/dotnet/System.Runtime.WindowsRuntime.UI.Xaml.dll",
-        "ref/dotnet/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/zh-hans/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/zh-hant/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Runtime.WindowsRuntime.UI.Xaml.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "Package",
       "files": [
+        "System.Security.Claims.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Security.Claims.dll",
         "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/de/System.Security.Claims.xml",
         "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
@@ -14034,22 +14359,18 @@
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
         "ref/dotnet/zh-hant/System.Security.Claims.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Claims.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "Package",
       "files": [
+        "System.Security.Principal.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Security.Principal.dll",
@@ -14059,6 +14380,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/de/System.Security.Principal.xml",
         "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
@@ -14066,8 +14389,6 @@
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
         "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
@@ -14075,14 +14396,14 @@
         "ref/netcore50/System.Security.Principal.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Security.Principal.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.ServiceModel.Duplex/4.0.0": {
       "sha512": "JFeDn+IsiwAVJkNNnM7MLefJOnzYhovaHnjk3lzEnUWkYZJeAKrcgLdK6GE2GNjb5mEV8Pad/E0JcA8eCr3eWQ==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.Duplex.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
@@ -14090,6 +14411,8 @@
         "lib/netcore50/System.ServiceModel.Duplex.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/8a542ab34ffb4a13958ce3d7279d9dae.psmdcp",
+        "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
         "ref/dotnet/de/System.ServiceModel.Duplex.xml",
         "ref/dotnet/es/System.ServiceModel.Duplex.xml",
         "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
@@ -14097,21 +14420,19 @@
         "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
         "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
         "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
-        "ref/dotnet/System.ServiceModel.Duplex.dll",
-        "ref/dotnet/System.ServiceModel.Duplex.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/netcore50/System.ServiceModel.Duplex.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.Duplex.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.ServiceModel.Http/4.0.10": {
       "sha512": "Vyl7lmvMlXJamtnDugoXuAgAQGSqtA7omK3zDBYByhbYeBC2hRBchgyXox7e5vEO+29TeB1IpoLWQGb7tO9h6A==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.Http.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.Http.dll",
@@ -14122,6 +14443,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/da6bab8a73fb4ac9af198a5f70d8aa64.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
         "ref/dotnet/de/System.ServiceModel.Http.xml",
         "ref/dotnet/es/System.ServiceModel.Http.xml",
         "ref/dotnet/fr/System.ServiceModel.Http.xml",
@@ -14129,22 +14454,18 @@
         "ref/dotnet/ja/System.ServiceModel.Http.xml",
         "ref/dotnet/ko/System.ServiceModel.Http.xml",
         "ref/dotnet/ru/System.ServiceModel.Http.xml",
-        "ref/dotnet/System.ServiceModel.Http.dll",
-        "ref/dotnet/System.ServiceModel.Http.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.ServiceModel.NetTcp/4.0.0": {
       "sha512": "lV2Cdcso9jOS0KBtgHZHzTLe/Lx/ERdPcvF4dlepUie6/+BOMYTOgg2C7OdpIjp3fwUNXq8nhU+IilmEyjuf/A==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.NetTcp.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
@@ -14152,6 +14473,8 @@
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/024bb3a15d5444e2b8b485ce4cf44640.psmdcp",
+        "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
@@ -14159,21 +14482,19 @@
         "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
-        "ref/dotnet/System.ServiceModel.NetTcp.dll",
-        "ref/dotnet/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/netcore50/System.ServiceModel.NetTcp.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.NetTcp.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.ServiceModel.Primitives/4.0.0": {
       "sha512": "uF5VYQWR07LgiZkzUr8qjwvqOaIAfwU566MneD4WuC14d8FLJNsAgCJUYhBGB7COjH7HTqnP9ZFmr6c+L83Stg==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
@@ -14181,6 +14502,8 @@
         "lib/netcore50/System.ServiceModel.Primitives.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/551694f534894508bee57aba617484c9.psmdcp",
+        "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
         "ref/dotnet/de/System.ServiceModel.Primitives.xml",
         "ref/dotnet/es/System.ServiceModel.Primitives.xml",
         "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
@@ -14188,21 +14511,19 @@
         "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
         "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
         "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
-        "ref/dotnet/System.ServiceModel.Primitives.dll",
-        "ref/dotnet/System.ServiceModel.Primitives.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/netcore50/System.ServiceModel.Primitives.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.Primitives.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.ServiceModel.Security/4.0.0": {
       "sha512": "sPVzsnd8w/TJsW/4sYA9eIGP+RtlpN0AhKLGKf9ywdGGmHPi0kkuX2mx412dM3GN0e4oifuISwvZqby/sI8Feg==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.Security.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.Security.dll",
@@ -14210,6 +14531,8 @@
         "lib/netcore50/System.ServiceModel.Security.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/724a153019f4439f95c814a98c7503f4.psmdcp",
+        "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
         "ref/dotnet/de/System.ServiceModel.Security.xml",
         "ref/dotnet/es/System.ServiceModel.Security.xml",
         "ref/dotnet/fr/System.ServiceModel.Security.xml",
@@ -14217,21 +14540,19 @@
         "ref/dotnet/ja/System.ServiceModel.Security.xml",
         "ref/dotnet/ko/System.ServiceModel.Security.xml",
         "ref/dotnet/ru/System.ServiceModel.Security.xml",
-        "ref/dotnet/System.ServiceModel.Security.dll",
-        "ref/dotnet/System.ServiceModel.Security.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/netcore50/System.ServiceModel.Security.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.Security.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "Package",
       "files": [
+        "System.Text.Encoding.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Text.Encoding.dll",
@@ -14242,6 +14563,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/de/System.Text.Encoding.xml",
         "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
@@ -14249,31 +14574,31 @@
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
-        "System.Text.Encoding.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
       ]
     },
     "System.Text.Encoding.CodePages/4.0.0": {
       "sha512": "ZHBTr1AXLjY9OuYR7pKx5xfN6QFye1kgd5QAbGrvfCOu7yxRnJs3VUaxERe1fOlnF0mi/xD/Dvb3T3x3HNuPWQ==",
       "type": "Package",
       "files": [
+        "System.Text.Encoding.CodePages.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Text.Encoding.CodePages.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Text.Encoding.CodePages.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/8a616349cf5c4e6ba7634969c080759b.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.Encoding.CodePages.dll",
+        "ref/dotnet/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/de/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/es/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/fr/System.Text.Encoding.CodePages.xml",
@@ -14281,21 +14606,17 @@
         "ref/dotnet/ja/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/ko/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/ru/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/System.Text.Encoding.CodePages.dll",
-        "ref/dotnet/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.CodePages.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Text.Encoding.CodePages.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "Package",
       "files": [
+        "System.Text.Encoding.Extensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
@@ -14306,6 +14627,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
@@ -14313,32 +14638,32 @@
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
-        "System.Text.Encoding.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "Package",
       "files": [
+        "System.Text.RegularExpressions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
         "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
@@ -14346,22 +14671,18 @@
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Text.RegularExpressions.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "Package",
       "files": [
+        "System.Threading.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Threading.dll",
@@ -14372,6 +14693,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/de/System.Threading.xml",
         "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
@@ -14379,29 +14704,27 @@
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
         "ref/dotnet/zh-hant/System.Threading.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
-        "System.Threading.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "Package",
       "files": [
+        "System.Threading.Overlapped.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
         "lib/netcore50/System.Threading.Overlapped.dll",
         "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
         "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
@@ -14409,18 +14732,16 @@
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
-        "ref/net46/System.Threading.Overlapped.dll",
-        "System.Threading.Overlapped.nuspec"
+        "ref/net46/System.Threading.Overlapped.dll"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "Package",
       "files": [
+        "System.Threading.Tasks.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Threading.Tasks.dll",
@@ -14431,6 +14752,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/de/System.Threading.Tasks.xml",
         "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
@@ -14438,39 +14763,35 @@
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
-        "System.Threading.Tasks.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "Package",
       "files": [
+        "System.Threading.Tasks.Dataflow.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp",
-        "System.Threading.Tasks.Dataflow.nuspec"
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "Package",
       "files": [
+        "System.Threading.Tasks.Parallel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
@@ -14479,6 +14800,8 @@
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
@@ -14486,22 +14809,20 @@
         "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
-        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Threading.Tasks.Parallel.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "Package",
       "files": [
+        "System.Threading.Timer.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Threading.Timer.dll",
@@ -14510,6 +14831,8 @@
         "lib/win81/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/de/System.Threading.Timer.xml",
         "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
@@ -14517,8 +14840,6 @@
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
         "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
@@ -14526,23 +14847,27 @@
         "ref/netcore50/System.Threading.Timer.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
-        "System.Threading.Timer.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "Package",
       "files": [
+        "System.Xml.ReaderWriter.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
         "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
@@ -14550,31 +14875,31 @@
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Xml.ReaderWriter.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "Package",
       "files": [
+        "System.Xml.XDocument.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Xml.XDocument.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/de/System.Xml.XDocument.xml",
         "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
@@ -14582,31 +14907,31 @@
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Xml.XDocument.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "Package",
       "files": [
+        "System.Xml.XmlDocument.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Xml.XmlDocument.dll",
         "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/de/System.Xml.XmlDocument.xml",
         "ref/dotnet/es/System.Xml.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XmlDocument.xml",
@@ -14614,22 +14939,18 @@
         "ref/dotnet/ja/System.Xml.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XmlDocument.xml",
-        "ref/dotnet/System.Xml.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Xml.XmlDocument.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Xml.XmlSerializer/4.0.10": {
       "sha512": "OKhE6vruk88z/hl0lmfrMvXteTASgJUagu6PT6S10i9uLbvDR3pTwB6jVgiwa2D2qtTB+eneZbS9jljhPXhTtg==",
       "type": "Package",
       "files": [
+        "System.Xml.XmlSerializer.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Xml.XmlSerializer.dll",
@@ -14640,6 +14961,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/1cffc42bca944f1d81ef3c3abdb0f0be.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Xml.XmlSerializer.dll",
+        "ref/dotnet/System.Xml.XmlSerializer.xml",
         "ref/dotnet/de/System.Xml.XmlSerializer.xml",
         "ref/dotnet/es/System.Xml.XmlSerializer.xml",
         "ref/dotnet/fr/System.Xml.XmlSerializer.xml",
@@ -14647,39 +14972,34 @@
         "ref/dotnet/ja/System.Xml.XmlSerializer.xml",
         "ref/dotnet/ko/System.Xml.XmlSerializer.xml",
         "ref/dotnet/ru/System.Xml.XmlSerializer.xml",
-        "ref/dotnet/System.Xml.XmlSerializer.dll",
-        "ref/dotnet/System.Xml.XmlSerializer.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlSerializer.xml",
         "ref/dotnet/zh-hant/System.Xml.XmlSerializer.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
-        "System.Xml.XmlSerializer.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll"
       ]
     },
     "Xamarin.Forms/2.0.1.6505": {
-      "sha512": "hmaHk7j3mWZY7rmWKq2/pnqDnbxFGQ20VXro2W2yaMS4ZDZBcQb6ePzH5/y0l6wRFgiPkA+oXPlrXbXICrE5hw==",
-      "type": "Package",
+      "sha512": "TBAEMEqugEwcEBtMo6PRqL3asZ6YmE3sJm4YoYnIy0nI8n1U7XwPkF/MUZu8Dl2qbAyqGjDxCgfYQrdI2cf7tw==",
+      "type": "package",
       "files": [
-        "[Content_Types].xml",
-        "_rels/.rels",
+        "Xamarin.Forms.2.0.1.6505.nupkg.sha512",
+        "Xamarin.Forms.nuspec",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.Decompiler.dll",
-        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.Cecil.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.CSharp.dll",
-        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.dll",
+        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.Cecil.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.Xml.dll",
-        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.dll",
+        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.Mdb.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.Pdb.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.Rocks.dll",
+        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Build.Tasks.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Core.dll",
-        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Xaml.dll",
+        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets",
         "lib/MonoAndroid10/FormsViewGroup.dll",
         "lib/MonoAndroid10/Xamarin.Forms.Core.dll",
         "lib/MonoAndroid10/Xamarin.Forms.Core.xml",
@@ -14693,6 +15013,18 @@
         "lib/MonoTouch10/Xamarin.Forms.Platform.iOS.Classic.dll",
         "lib/MonoTouch10/Xamarin.Forms.Xaml.dll",
         "lib/MonoTouch10/Xamarin.Forms.Xaml.xml",
+        "lib/WP80/Xamarin.Forms.Core.dll",
+        "lib/WP80/Xamarin.Forms.Core.xml",
+        "lib/WP80/Xamarin.Forms.Platform.WP8.dll",
+        "lib/WP80/Xamarin.Forms.Platform.dll",
+        "lib/WP80/Xamarin.Forms.Xaml.dll",
+        "lib/WP80/Xamarin.Forms.Xaml.xml",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Core.dll",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Core.xml",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Platform.dll",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Platform.iOS.dll",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Xaml.dll",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Xaml.xml",
         "lib/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Core.dll",
         "lib/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Core.xml",
         "lib/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Platform.dll",
@@ -14700,7 +15032,6 @@
         "lib/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Xaml.xml",
         "lib/uap10.0/Xamarin.Forms.Core.dll",
         "lib/uap10.0/Xamarin.Forms.Core.xml",
-        "lib/uap10.0/Xamarin.Forms.Platform.dll",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP.pri",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP/FormsTextBox.xbf",
@@ -14708,34 +15039,27 @@
         "lib/uap10.0/Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP/Resources.xbf",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.xr.xml",
+        "lib/uap10.0/Xamarin.Forms.Platform.dll",
         "lib/uap10.0/Xamarin.Forms.Xaml.dll",
         "lib/uap10.0/Xamarin.Forms.Xaml.xml",
         "lib/win81/Xamarin.Forms.Core.dll",
         "lib/win81/Xamarin.Forms.Core.xml",
-        "lib/win81/Xamarin.Forms.Platform.dll",
-        "lib/win81/Xamarin.Forms.Platform.WinRT.dll",
-        "lib/win81/Xamarin.Forms.Platform.WinRT.pri",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet.dll",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet.pri",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet/Resources.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet/TabletResources.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet/Xamarin.Forms.Platform.WinRT.Tablet.xr.xml",
+        "lib/win81/Xamarin.Forms.Platform.WinRT.dll",
+        "lib/win81/Xamarin.Forms.Platform.WinRT.pri",
         "lib/win81/Xamarin.Forms.Platform.WinRT/FormsTextBox.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT/PageControl.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT/StepperControl.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.xr.xml",
+        "lib/win81/Xamarin.Forms.Platform.dll",
         "lib/win81/Xamarin.Forms.Xaml.dll",
         "lib/win81/Xamarin.Forms.Xaml.xml",
-        "lib/WP80/Xamarin.Forms.Core.dll",
-        "lib/WP80/Xamarin.Forms.Core.xml",
-        "lib/WP80/Xamarin.Forms.Platform.dll",
-        "lib/WP80/Xamarin.Forms.Platform.WP8.dll",
-        "lib/WP80/Xamarin.Forms.Xaml.dll",
-        "lib/WP80/Xamarin.Forms.Xaml.xml",
         "lib/wpa81/Xamarin.Forms.Core.dll",
         "lib/wpa81/Xamarin.Forms.Core.xml",
-        "lib/wpa81/Xamarin.Forms.Platform.dll",
-        "lib/wpa81/Xamarin.Forms.Platform.WinRT.dll",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone.dll",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone.pri",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone/FormsTextBoxStyle.xbf",
@@ -14743,24 +15067,18 @@
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone/Resources.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone/SearchBox.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone/Xamarin.Forms.Platform.WinRT.Phone.xr.xml",
+        "lib/wpa81/Xamarin.Forms.Platform.WinRT.dll",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.pri",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT/FormsTextBox.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT/PageControl.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT/StepperControl.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.xr.xml",
+        "lib/wpa81/Xamarin.Forms.Platform.dll",
         "lib/wpa81/Xamarin.Forms.Xaml.dll",
         "lib/wpa81/Xamarin.Forms.Xaml.xml",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Core.dll",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Core.xml",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Platform.dll",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Platform.iOS.dll",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Xaml.dll",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Xaml.xml",
-        "package/services/metadata/core-properties/a020f0c26e2c4330b18512b6bcf23b4e.psmdcp",
-        "tools/init.ps1",
         "tools/Xamarin.Forms.Core.Design.dll",
         "tools/Xamarin.Forms.Xaml.Design.dll",
-        "Xamarin.Forms.nuspec"
+        "tools/init.ps1"
       ]
     }
   },

--- a/ImageCircle/TestAppsCircles/TestAppsCircles.UWP/project.lock.json
+++ b/ImageCircle/TestAppsCircles/TestAppsCircles.UWP/project.lock.json
@@ -5,22 +5,22 @@
     "UAP,Version=v10.0": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -31,156 +31,210 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.dll": {},
           "lib/netcore50/System.Net.dll": {},
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {}
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Core.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Net.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Numerics.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Windows.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {},
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -191,8 +245,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -203,10 +257,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -217,30 +271,36 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -251,14 +311,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -269,12 +329,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -285,13 +345,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -302,7 +362,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -313,17 +373,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -334,10 +394,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -348,15 +408,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -371,28 +431,46 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Tools/4.0.0": {
@@ -401,80 +479,110 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -485,31 +593,37 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.IO.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -520,14 +634,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -538,21 +652,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -563,7 +677,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -574,15 +688,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -593,13 +707,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -610,11 +724,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -625,39 +739,45 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -668,13 +788,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -685,20 +805,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -709,8 +829,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -721,9 +841,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -734,8 +854,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -746,16 +866,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -766,8 +886,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -778,10 +898,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -792,10 +912,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -806,9 +926,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -819,11 +939,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -834,51 +954,57 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
         },
         "runtime": {
           "lib/netcore50/System.Private.DataContractSerialization.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -889,44 +1015,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -941,26 +1067,38 @@
         },
         "runtime": {
           "lib/netcore50/System.Private.Uri.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -971,55 +1109,67 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -1030,92 +1180,134 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
@@ -1124,14 +1316,20 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -1142,19 +1340,25 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -1165,43 +1369,55 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -1212,14 +1428,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -1230,7 +1446,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -1241,8 +1457,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -1253,8 +1469,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -1265,8 +1481,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -1277,8 +1493,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -1289,8 +1505,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -1301,28 +1517,34 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -1333,24 +1555,30 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -1361,24 +1589,30 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -1389,28 +1623,34 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -1421,14 +1661,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -1443,24 +1683,30 @@
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1471,17 +1717,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -1492,16 +1738,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1512,41 +1758,47 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -1554,22 +1806,22 @@
     "UAP,Version=v10.0/win10-arm": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -1580,125 +1832,129 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.dll": {},
           "lib/netcore50/System.Net.dll": {},
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {}
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR-arm": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.CoreCLR-arm/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1718,61 +1974,61 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -1783,8 +2039,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -1795,10 +2051,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -1809,11 +2065,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -1824,15 +2080,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -1843,14 +2099,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -1861,12 +2117,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -1877,13 +2133,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -1894,7 +2150,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -1905,17 +2161,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -1926,10 +2182,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -1940,15 +2196,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -1967,7 +2223,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -1978,7 +2234,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -1997,16 +2253,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -2017,18 +2273,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -2039,7 +2297,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -2050,8 +2308,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -2062,11 +2320,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -2077,12 +2335,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -2093,15 +2351,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-arm": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -2117,14 +2376,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2135,21 +2394,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -2160,7 +2419,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -2171,15 +2430,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -2190,13 +2449,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2207,11 +2466,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -2222,19 +2481,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -2245,16 +2506,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -2265,13 +2526,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -2282,20 +2543,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -2306,8 +2567,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -2318,9 +2579,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -2331,8 +2592,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -2343,16 +2604,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -2363,8 +2624,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -2375,10 +2636,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -2389,10 +2650,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -2403,9 +2664,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -2416,11 +2677,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -2431,24 +2692,26 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -2459,23 +2722,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -2486,44 +2749,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -2542,9 +2805,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -2555,9 +2818,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -2568,14 +2831,16 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -2586,11 +2851,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -2601,9 +2866,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2614,10 +2879,10 @@
       },
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -2628,13 +2893,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -2645,20 +2910,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -2669,8 +2934,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -2681,14 +2946,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -2699,9 +2964,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -2712,7 +2977,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -2723,7 +2988,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -2734,7 +2999,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -2745,10 +3010,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -2767,10 +3032,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -2781,7 +3046,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -2792,8 +3057,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -2804,8 +3069,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -2816,16 +3081,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -2836,11 +3101,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -2851,14 +3116,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -2869,7 +3134,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -2880,8 +3145,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -2892,8 +3157,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -2904,8 +3169,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -2916,8 +3181,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -2928,8 +3193,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -2940,7 +3205,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -2951,17 +3216,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -2972,8 +3237,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -2984,12 +3249,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -3000,8 +3265,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -3012,12 +3277,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -3028,7 +3293,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -3039,17 +3304,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -3060,14 +3325,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -3086,20 +3351,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -3110,17 +3375,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -3131,16 +3396,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -3151,22 +3416,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -3178,14 +3445,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -3193,22 +3460,22 @@
     "UAP,Version=v10.0/win10-arm-aot": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -3219,185 +3486,189 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
-          "runtimes/aot/lib/netcore50/mscorlib.dll": {},
           "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "runtimes/aot/lib/netcore50/System.Core.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
           "runtimes/aot/lib/netcore50/System.Net.dll": {},
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {}
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
+          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.Native": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.Native/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         }
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -3408,8 +3679,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -3420,10 +3691,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -3434,11 +3705,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -3449,15 +3720,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -3468,14 +3739,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -3486,12 +3757,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -3502,13 +3773,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -3519,7 +3790,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -3530,17 +3801,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -3551,10 +3822,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -3565,15 +3836,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -3592,7 +3863,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -3603,7 +3874,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -3622,16 +3893,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -3642,18 +3913,18 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -3664,7 +3935,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -3675,8 +3946,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -3687,11 +3958,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -3702,12 +3973,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -3718,15 +3989,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-arm": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -3742,14 +4014,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -3760,21 +4032,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -3785,7 +4057,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -3796,15 +4068,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -3815,13 +4087,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -3832,11 +4104,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -3847,19 +4119,19 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -3870,16 +4142,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -3890,13 +4162,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -3907,20 +4179,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -3931,8 +4203,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -3943,9 +4215,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -3956,8 +4228,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -3968,16 +4240,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -3988,8 +4260,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -4000,10 +4272,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -4014,10 +4286,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -4028,9 +4300,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -4041,11 +4313,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -4056,24 +4328,24 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -4084,23 +4356,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -4111,44 +4383,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -4167,9 +4439,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -4180,9 +4452,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -4193,14 +4465,14 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -4211,11 +4483,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -4226,9 +4498,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -4239,13 +4511,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -4256,20 +4528,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -4280,8 +4552,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -4292,14 +4564,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -4310,9 +4582,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -4323,7 +4595,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -4334,7 +4606,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -4345,7 +4617,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -4356,10 +4628,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -4378,10 +4650,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -4392,7 +4664,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -4403,8 +4675,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -4415,8 +4687,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -4427,16 +4699,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -4447,11 +4719,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -4462,14 +4734,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -4480,7 +4752,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -4491,8 +4763,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -4503,8 +4775,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -4515,8 +4787,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -4527,8 +4799,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -4539,8 +4811,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -4551,7 +4823,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -4562,17 +4834,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -4583,8 +4855,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -4595,12 +4867,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -4611,8 +4883,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -4623,12 +4895,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -4639,7 +4911,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -4650,17 +4922,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -4671,14 +4943,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -4697,20 +4969,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -4721,17 +4993,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -4742,16 +5014,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -4762,22 +5034,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -4789,14 +5063,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -4804,22 +5078,22 @@
     "UAP,Version=v10.0/win10-x64": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -4830,125 +5104,130 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.dll": {},
           "lib/netcore50/System.Net.dll": {},
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {}
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR-x64": "1.0.0",
+          "Microsoft.NETCore.Windows.ApiSets-x64": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.CoreCLR-x64/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -4968,41 +5247,41 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.NETCore.Windows.ApiSets-x64/1.0.0": {
@@ -5012,22 +5291,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -5038,8 +5317,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -5050,10 +5329,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -5064,11 +5343,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -5079,15 +5358,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -5098,14 +5377,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -5116,12 +5395,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -5132,13 +5411,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -5149,7 +5428,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -5160,17 +5439,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -5181,10 +5460,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -5195,15 +5474,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -5222,7 +5501,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -5233,7 +5512,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -5252,16 +5531,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -5272,18 +5551,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -5294,7 +5575,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -5305,8 +5586,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -5317,11 +5598,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -5332,12 +5613,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -5348,15 +5629,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-x64": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -5372,14 +5654,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -5390,21 +5672,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -5415,7 +5697,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -5426,15 +5708,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -5445,13 +5727,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -5462,11 +5744,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -5477,19 +5759,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -5500,16 +5784,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -5520,13 +5804,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -5537,20 +5821,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -5561,8 +5845,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -5573,9 +5857,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -5586,8 +5870,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -5598,16 +5882,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -5618,8 +5902,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -5630,10 +5914,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -5644,10 +5928,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -5658,9 +5942,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -5671,11 +5955,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -5686,24 +5970,26 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -5714,23 +6000,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -5741,44 +6027,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -5797,9 +6083,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -5810,9 +6096,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -5823,14 +6109,16 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -5841,11 +6129,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -5856,9 +6144,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -5869,10 +6157,10 @@
       },
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -5883,13 +6171,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -5900,20 +6188,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -5924,8 +6212,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -5936,14 +6224,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -5954,9 +6242,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -5967,7 +6255,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -5978,7 +6266,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -5989,7 +6277,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -6000,10 +6288,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -6022,10 +6310,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -6036,7 +6324,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -6047,8 +6335,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -6059,8 +6347,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -6071,16 +6359,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -6091,11 +6379,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -6106,14 +6394,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -6124,7 +6412,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -6135,8 +6423,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -6147,8 +6435,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -6159,8 +6447,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -6171,8 +6459,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -6183,8 +6471,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -6195,7 +6483,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -6206,17 +6494,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -6227,8 +6515,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -6239,12 +6527,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -6255,8 +6543,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -6267,12 +6555,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -6283,7 +6571,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -6294,17 +6582,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -6315,14 +6603,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -6341,20 +6629,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -6365,17 +6653,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -6386,16 +6674,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -6406,22 +6694,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -6433,14 +6723,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -6448,22 +6738,22 @@
     "UAP,Version=v10.0/win10-x64-aot": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -6474,185 +6764,189 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
-          "runtimes/aot/lib/netcore50/mscorlib.dll": {},
           "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "runtimes/aot/lib/netcore50/System.Core.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
           "runtimes/aot/lib/netcore50/System.Net.dll": {},
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {}
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
+          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.Native": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.Native/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         }
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -6663,8 +6957,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -6675,10 +6969,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -6689,11 +6983,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -6704,15 +6998,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -6723,14 +7017,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -6741,12 +7035,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -6757,13 +7051,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -6774,7 +7068,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -6785,17 +7079,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -6806,10 +7100,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -6820,15 +7114,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -6847,7 +7141,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -6858,7 +7152,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -6877,16 +7171,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -6897,18 +7191,18 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -6919,7 +7213,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -6930,8 +7224,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -6942,11 +7236,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -6957,12 +7251,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -6973,15 +7267,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-x64": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -6997,14 +7292,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -7015,21 +7310,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -7040,7 +7335,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -7051,15 +7346,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -7070,13 +7365,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -7087,11 +7382,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -7102,19 +7397,19 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -7125,16 +7420,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -7145,13 +7440,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -7162,20 +7457,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -7186,8 +7481,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -7198,9 +7493,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -7211,8 +7506,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -7223,16 +7518,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -7243,8 +7538,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -7255,10 +7550,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -7269,10 +7564,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -7283,9 +7578,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -7296,11 +7591,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -7311,24 +7606,24 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -7339,23 +7634,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -7366,44 +7661,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -7422,9 +7717,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -7435,9 +7730,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -7448,14 +7743,14 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -7466,11 +7761,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -7481,9 +7776,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -7494,13 +7789,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -7511,20 +7806,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -7535,8 +7830,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -7547,14 +7842,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -7565,9 +7860,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -7578,7 +7873,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -7589,7 +7884,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -7600,7 +7895,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -7611,10 +7906,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -7633,10 +7928,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -7647,7 +7942,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -7658,8 +7953,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -7670,8 +7965,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -7682,16 +7977,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -7702,11 +7997,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -7717,14 +8012,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -7735,7 +8030,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -7746,8 +8041,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -7758,8 +8053,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -7770,8 +8065,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -7782,8 +8077,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -7794,8 +8089,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -7806,7 +8101,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -7817,17 +8112,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -7838,8 +8133,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -7850,12 +8145,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -7866,8 +8161,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -7878,12 +8173,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -7894,7 +8189,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -7905,17 +8200,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -7926,14 +8221,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -7952,20 +8247,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -7976,17 +8271,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -7997,16 +8292,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -8017,22 +8312,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -8044,14 +8341,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -8059,22 +8356,22 @@
     "UAP,Version=v10.0/win10-x86": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -8085,125 +8382,130 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.dll": {},
           "lib/netcore50/System.Net.dll": {},
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
           "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {}
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR-x86": "1.0.0",
+          "Microsoft.NETCore.Windows.ApiSets-x86": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -8223,41 +8525,41 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
@@ -8267,22 +8569,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -8293,8 +8595,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -8305,10 +8607,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -8319,11 +8621,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -8334,15 +8636,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -8353,14 +8655,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -8371,12 +8673,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -8387,13 +8689,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -8404,7 +8706,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -8415,17 +8717,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -8436,10 +8738,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -8450,15 +8752,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -8477,7 +8779,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -8488,7 +8790,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -8507,16 +8809,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -8527,18 +8829,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -8549,7 +8853,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -8560,8 +8864,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -8572,11 +8876,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -8587,12 +8891,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -8603,15 +8907,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-x86": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -8627,14 +8932,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -8645,21 +8950,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -8670,7 +8975,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -8681,15 +8986,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -8700,13 +9005,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -8717,11 +9022,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -8732,19 +9037,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -8755,16 +9062,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -8775,13 +9082,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -8792,20 +9099,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -8816,8 +9123,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -8828,9 +9135,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -8841,8 +9148,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -8853,16 +9160,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -8873,8 +9180,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -8885,10 +9192,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -8899,10 +9206,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -8913,9 +9220,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -8926,11 +9233,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -8941,24 +9248,26 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -8969,23 +9278,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -8996,44 +9305,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -9052,9 +9361,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -9065,9 +9374,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -9078,14 +9387,16 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -9096,11 +9407,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -9111,9 +9422,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -9124,10 +9435,10 @@
       },
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -9138,13 +9449,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -9155,20 +9466,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -9179,8 +9490,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -9191,14 +9502,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -9209,9 +9520,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -9222,7 +9533,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -9233,7 +9544,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -9244,7 +9555,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -9255,10 +9566,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -9277,10 +9588,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -9291,7 +9602,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -9302,8 +9613,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -9314,8 +9625,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -9326,16 +9637,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -9346,11 +9657,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -9361,14 +9672,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -9379,7 +9690,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -9390,8 +9701,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -9402,8 +9713,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -9414,8 +9725,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -9426,8 +9737,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -9438,8 +9749,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -9450,7 +9761,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -9461,17 +9772,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -9482,8 +9793,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -9494,12 +9805,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -9510,8 +9821,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -9522,12 +9833,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -9538,7 +9849,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -9549,17 +9860,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -9570,14 +9881,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -9596,20 +9907,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -9620,17 +9931,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -9641,16 +9952,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -9661,22 +9972,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -9688,14 +10001,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -9703,22 +10016,22 @@
     "UAP,Version=v10.0/win10-x86-aot": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.CSharp.dll": {}
@@ -9729,185 +10042,189 @@
       },
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
-          "Microsoft.CSharp": "[4.0.0, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )",
-          "Microsoft.VisualBasic": "[10.0.0, )",
-          "System.AppContext": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.ComponentModel.Annotations": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tools": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Calendars": "[4.0.0, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.Compression.ZipFile": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.UnmanagedMemoryStream": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Parallel": "[4.0.0, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Metadata": "[1.0.22, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Numerics": "[4.0.0, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Tasks.Dataflow": "[4.5.25, )",
-          "System.Threading.Tasks.Parallel": "[4.0.0, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )"
+          "Microsoft.CSharp": "4.0.0",
+          "Microsoft.NETCore.Targets": "1.0.0",
+          "Microsoft.VisualBasic": "10.0.0",
+          "System.AppContext": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.Immutable": "1.1.37",
+          "System.ComponentModel": "4.0.0",
+          "System.ComponentModel.Annotations": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.Compression.ZipFile": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Parallel": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NetworkInformation": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Numerics.Vectors": "4.1.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Metadata": "1.0.22",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Tasks.Dataflow": "4.5.25",
+          "System.Threading.Tasks.Parallel": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XDocument": "4.0.10"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
       "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime": "[1.0.0, )"
+          "Microsoft.NETCore.Runtime": "1.0.0"
         },
         "compile": {
-          "ref/netcore50/mscorlib.dll": {},
           "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.dll": {},
           "ref/netcore50/System.Net.dll": {},
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
           "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {}
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
-          "runtimes/aot/lib/netcore50/mscorlib.dll": {},
           "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
           "runtimes/aot/lib/netcore50/System.Core.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
           "runtimes/aot/lib/netcore50/System.Net.dll": {},
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {}
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
+          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.0": {},
+      "Microsoft.NETCore.Runtime/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.Native": "1.0.0"
+        }
+      },
       "Microsoft.NETCore.Runtime.Native/1.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Globalization": "[4.0.10, 4.0.10]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.IO": "[4.0.10, 4.0.10]",
-          "System.ObjectModel": "[4.0.10, 4.0.10]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Reflection": "[4.0.10, 4.0.10]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
-          "System.Text.Encoding": "[4.0.10, 4.0.10]",
-          "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
-          "System.Threading": "[4.0.10, 4.0.10]",
-          "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]"
+          "System.Collections": "[4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0]",
+          "System.Diagnostics.Debug": "[4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20]",
+          "System.Globalization": "[4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0]",
+          "System.IO": "[4.0.10]",
+          "System.ObjectModel": "[4.0.10]",
+          "System.Private.Uri": "[4.0.0]",
+          "System.Reflection": "[4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0]",
+          "System.Runtime": "[4.0.20]",
+          "System.Runtime.Extensions": "[4.0.10]",
+          "System.Runtime.Handles": "[4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20]",
+          "System.Text.Encoding": "[4.0.10]",
+          "System.Text.Encoding.Extensions": "[4.0.10]",
+          "System.Threading": "[4.0.10]",
+          "System.Threading.Tasks": "[4.0.10]",
+          "System.Threading.Timer": "[4.0.0]"
         }
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "[1.0.0, )",
-          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "[5.0.0, )"
+          "Microsoft.NETCore.Platforms": "1.0.0",
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.0"
         }
       },
       "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {},
       "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
         "dependencies": {
-          "Microsoft.NETCore": "[5.0.0, )",
-          "Microsoft.NETCore.Portable.Compatibility": "[1.0.0, )",
-          "Microsoft.NETCore.Runtime": "[1.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Data.Common": "[4.0.0, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.StackTrace": "[4.0.0, )",
-          "System.IO.IsolatedStorage": "[4.0.0, )",
-          "System.Net.Http.Rtc": "[4.0.0, )",
-          "System.Net.Requests": "[4.0.10, )",
-          "System.Net.Sockets": "[4.0.0, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Numerics.Vectors.WindowsRuntime": "[4.0.0, )",
-          "System.Reflection.Context": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Runtime.Serialization.Json": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "[4.0.0, )",
-          "System.ServiceModel.Duplex": "[4.0.0, )",
-          "System.ServiceModel.Http": "[4.0.10, )",
-          "System.ServiceModel.NetTcp": "[4.0.0, )",
-          "System.ServiceModel.Primitives": "[4.0.0, )",
-          "System.ServiceModel.Security": "[4.0.0, )",
-          "System.Text.Encoding.CodePages": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "Microsoft.NETCore": "5.0.0",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+          "Microsoft.NETCore.Runtime": "1.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Data.Common": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.0",
+          "System.IO.IsolatedStorage": "4.0.0",
+          "System.Net.Http.Rtc": "4.0.0",
+          "System.Net.Requests": "4.0.10",
+          "System.Net.Sockets": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.0",
+          "System.Reflection.Context": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.0",
+          "System.ServiceModel.Duplex": "4.0.0",
+          "System.ServiceModel.Http": "4.0.10",
+          "System.ServiceModel.NetTcp": "4.0.0",
+          "System.ServiceModel.Primitives": "4.0.0",
+          "System.ServiceModel.Security": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         }
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Dynamic.Runtime": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/netcore50/Microsoft.VisualBasic.dll": {}
@@ -9918,8 +10235,8 @@
       },
       "Microsoft.Win32.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -9930,10 +10247,10 @@
       },
       "System.AppContext/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.AppContext.dll": {}
@@ -9944,11 +10261,11 @@
       },
       "System.Collections/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -9959,15 +10276,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -9978,14 +10295,14 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Collections.Immutable.dll": {}
@@ -9996,12 +10313,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -10012,13 +10329,13 @@
       },
       "System.Collections.Specialized/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Globalization.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -10029,7 +10346,7 @@
       },
       "System.ComponentModel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ComponentModel.dll": {}
@@ -10040,17 +10357,17 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.ComponentModel": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.ComponentModel": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -10061,10 +10378,10 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -10075,15 +10392,15 @@
       },
       "System.Data.Common/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Data.Common.dll": {}
@@ -10102,7 +10419,7 @@
       },
       "System.Diagnostics.Debug/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -10113,7 +10430,7 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -10132,16 +10449,16 @@
       },
       "System.Diagnostics.Tracing/4.0.20": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -10152,18 +10469,18 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -10174,7 +10491,7 @@
       },
       "System.Globalization/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -10185,8 +10502,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -10197,11 +10514,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -10212,12 +10529,12 @@
       },
       "System.IO/4.0.10": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -10228,15 +10545,16 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.Compression.clrcompression-x86": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.IO.Compression.dll": {}
@@ -10252,14 +10570,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -10270,21 +10588,21 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -10295,7 +10613,7 @@
       },
       "System.IO.FileSystem.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -10306,15 +10624,15 @@
       },
       "System.IO.IsolatedStorage/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.IsolatedStorage.dll": {}
@@ -10325,13 +10643,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -10342,11 +10660,11 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.dll": {}
@@ -10357,19 +10675,19 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -10380,16 +10698,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Linq.Parallel.dll": {}
@@ -10400,13 +10718,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Linq.Queryable.dll": {}
@@ -10417,20 +10735,20 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
@@ -10441,8 +10759,8 @@
       },
       "System.Net.Http.Rtc/4.0.0": {
         "dependencies": {
-          "System.Net.Http": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Net.Http": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.Rtc.dll": {}
@@ -10453,9 +10771,9 @@
       },
       "System.Net.NetworkInformation/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.NetworkInformation.dll": {}
@@ -10466,8 +10784,8 @@
       },
       "System.Net.Primitives/4.0.10": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -10478,16 +10796,16 @@
       },
       "System.Net.Requests/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.Requests.dll": {}
@@ -10498,8 +10816,8 @@
       },
       "System.Net.Sockets/4.0.0": {
         "dependencies": {
-          "System.Private.Networking": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.Networking": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -10510,10 +10828,10 @@
       },
       "System.Net.WebHeaderCollection/4.0.0": {
         "dependencies": {
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -10524,10 +10842,10 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Numerics.Vectors.dll": {}
@@ -10538,9 +10856,9 @@
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
         "dependencies": {
-          "System.Numerics.Vectors": "[4.1.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Numerics.Vectors": "4.1.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll": {}
@@ -10551,11 +10869,11 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -10566,24 +10884,24 @@
       },
       "System.Private.DataContractSerialization/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -10594,23 +10912,23 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -10621,44 +10939,44 @@
       },
       "System.Private.ServiceModel/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Collections.NonGeneric": "[4.0.0, )",
-          "System.Collections.Specialized": "[4.0.0, )",
-          "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )",
-          "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.Http": "[4.0.0, )",
-          "System.Net.Primitives": "[4.0.10, )",
-          "System.Net.WebHeaderCollection": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.DispatchProxy": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )",
-          "System.Runtime.Serialization.Xml": "[4.0.10, )",
-          "System.Runtime.WindowsRuntime": "[4.0.10, )",
-          "System.Security.Claims": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.Timer": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.XmlSerializer": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Runtime.WindowsRuntime": "4.0.10",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Timer": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Xml.XmlSerializer": "4.0.10"
         },
         "compile": {
           "ref/netcore50/_._": {}
@@ -10677,9 +10995,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -10690,9 +11008,9 @@
       },
       "System.Reflection.Context/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Context.dll": {}
@@ -10703,14 +11021,14 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -10721,11 +11039,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -10736,9 +11054,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -10749,13 +11067,13 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Extensions.dll": {}
@@ -10766,20 +11084,20 @@
       },
       "System.Reflection.Metadata/1.0.22": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Immutable": "1.1.37",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Reflection.Metadata.dll": {}
@@ -10790,8 +11108,8 @@
       },
       "System.Reflection.Primitives/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Reflection.Primitives.dll": {}
@@ -10802,14 +11120,14 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Diagnostics.Contracts": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -10820,9 +11138,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.Resources.ResourceManager.dll": {}
@@ -10833,7 +11151,7 @@
       },
       "System.Runtime/4.0.20": {
         "dependencies": {
-          "System.Private.Uri": "[4.0.0, )"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -10844,7 +11162,7 @@
       },
       "System.Runtime.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -10855,7 +11173,7 @@
       },
       "System.Runtime.Handles/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -10866,10 +11184,10 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )"
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -10888,10 +11206,10 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Numerics.dll": {}
@@ -10902,7 +11220,7 @@
       },
       "System.Runtime.Serialization.Json/4.0.0": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )"
+          "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -10913,8 +11231,8 @@
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -10925,8 +11243,8 @@
       },
       "System.Runtime.Serialization.Xml/4.0.10": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "[4.0.0, )",
-          "System.Runtime.Serialization.Primitives": "[4.0.10, )"
+          "System.Private.DataContractSerialization": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -10937,16 +11255,16 @@
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
         "dependencies": {
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -10957,11 +11275,11 @@
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
         "dependencies": {
-          "System.Globalization": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.WindowsRuntime": "[4.0.0, )"
+          "System.Globalization": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -10972,14 +11290,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Security.Principal": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -10990,7 +11308,7 @@
       },
       "System.Security.Principal/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Security.Principal.dll": {}
@@ -11001,8 +11319,8 @@
       },
       "System.ServiceModel.Duplex/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -11013,8 +11331,8 @@
       },
       "System.ServiceModel.Http/4.0.10": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -11025,8 +11343,8 @@
       },
       "System.ServiceModel.NetTcp/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -11037,8 +11355,8 @@
       },
       "System.ServiceModel.Primitives/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -11049,8 +11367,8 @@
       },
       "System.ServiceModel.Security/4.0.0": {
         "dependencies": {
-          "System.Private.ServiceModel": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )"
+          "System.Private.ServiceModel": "4.0.0",
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/netcore50/System.ServiceModel.Security.dll": {}
@@ -11061,7 +11379,7 @@
       },
       "System.Text.Encoding/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -11072,17 +11390,17 @@
       },
       "System.Text.Encoding.CodePages/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -11093,8 +11411,8 @@
       },
       "System.Text.Encoding.Extensions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -11105,12 +11423,12 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -11121,8 +11439,8 @@
       },
       "System.Threading/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -11133,12 +11451,12 @@
       },
       "System.Threading.Overlapped/4.0.0": {
         "dependencies": {
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -11149,7 +11467,7 @@
       },
       "System.Threading.Tasks/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )"
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -11160,17 +11478,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )"
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -11181,14 +11499,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -11207,20 +11525,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -11231,17 +11549,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -11252,16 +11570,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -11272,22 +11590,24 @@
       },
       "System.Xml.XmlSerializer/4.0.10": {
         "dependencies": {
-          "System.Collections": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XmlDocument": "[4.0.0, )"
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -11299,14 +11619,14 @@
       "Xamarin.Forms/2.0.1.6505": {
         "compile": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         },
         "runtime": {
           "lib/uap10.0/Xamarin.Forms.Core.dll": {},
-          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll": {},
+          "lib/uap10.0/Xamarin.Forms.Platform.dll": {},
           "lib/uap10.0/Xamarin.Forms.Xaml.dll": {}
         }
       }
@@ -11317,11 +11637,12 @@
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "Package",
       "files": [
+        "Microsoft.CSharp.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/Microsoft.CSharp.dll",
         "lib/net45/_._",
         "lib/netcore50/Microsoft.CSharp.dll",
         "lib/win8/_._",
@@ -11329,21 +11650,20 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.CSharp.nuspec",
         "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/de/Microsoft.CSharp.xml",
         "ref/dotnet/es/Microsoft.CSharp.xml",
         "ref/dotnet/fr/Microsoft.CSharp.xml",
         "ref/dotnet/it/Microsoft.CSharp.xml",
         "ref/dotnet/ja/Microsoft.CSharp.xml",
         "ref/dotnet/ko/Microsoft.CSharp.xml",
-        "ref/dotnet/Microsoft.CSharp.dll",
-        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/ru/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/netcore50/Microsoft.CSharp.dll",
         "ref/netcore50/Microsoft.CSharp.xml",
@@ -11358,10 +11678,10 @@
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.nuspec",
         "[Content_Types].xml",
         "_._",
         "_rels/.rels",
-        "Microsoft.NETCore.nuspec",
         "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp"
       ]
     },
@@ -11369,9 +11689,9 @@
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Platforms.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Platforms.nuspec",
         "package/services/metadata/core-properties/36b51d4c6b524527902ff1a182a64e42.psmdcp",
         "runtime.json"
       ]
@@ -11380,90 +11700,90 @@
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Portable.Compatibility.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
-        "lib/dnxcore50/System.dll",
         "lib/dnxcore50/System.Net.dll",
         "lib/dnxcore50/System.Numerics.dll",
         "lib/dnxcore50/System.Runtime.Serialization.dll",
-        "lib/dnxcore50/System.ServiceModel.dll",
         "lib/dnxcore50/System.ServiceModel.Web.dll",
+        "lib/dnxcore50/System.ServiceModel.dll",
         "lib/dnxcore50/System.Windows.dll",
-        "lib/dnxcore50/System.Xml.dll",
         "lib/dnxcore50/System.Xml.Linq.dll",
         "lib/dnxcore50/System.Xml.Serialization.dll",
+        "lib/dnxcore50/System.Xml.dll",
+        "lib/dnxcore50/System.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/netcore50/System.Core.dll",
-        "lib/netcore50/System.dll",
         "lib/netcore50/System.Net.dll",
         "lib/netcore50/System.Numerics.dll",
         "lib/netcore50/System.Runtime.Serialization.dll",
-        "lib/netcore50/System.ServiceModel.dll",
         "lib/netcore50/System.ServiceModel.Web.dll",
+        "lib/netcore50/System.ServiceModel.dll",
         "lib/netcore50/System.Windows.dll",
-        "lib/netcore50/System.Xml.dll",
         "lib/netcore50/System.Xml.Linq.dll",
         "lib/netcore50/System.Xml.Serialization.dll",
+        "lib/netcore50/System.Xml.dll",
+        "lib/netcore50/System.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
         "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
-        "ref/dotnet/mscorlib.dll",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
-        "ref/dotnet/System.dll",
         "ref/dotnet/System.Net.dll",
         "ref/dotnet/System.Numerics.dll",
         "ref/dotnet/System.Runtime.Serialization.dll",
-        "ref/dotnet/System.ServiceModel.dll",
         "ref/dotnet/System.ServiceModel.Web.dll",
+        "ref/dotnet/System.ServiceModel.dll",
         "ref/dotnet/System.Windows.dll",
-        "ref/dotnet/System.Xml.dll",
         "ref/dotnet/System.Xml.Linq.dll",
         "ref/dotnet/System.Xml.Serialization.dll",
+        "ref/dotnet/System.Xml.dll",
+        "ref/dotnet/System.dll",
+        "ref/dotnet/mscorlib.dll",
         "ref/net45/_._",
-        "ref/netcore50/mscorlib.dll",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
-        "ref/netcore50/System.dll",
         "ref/netcore50/System.Net.dll",
         "ref/netcore50/System.Numerics.dll",
         "ref/netcore50/System.Runtime.Serialization.dll",
-        "ref/netcore50/System.ServiceModel.dll",
         "ref/netcore50/System.ServiceModel.Web.dll",
+        "ref/netcore50/System.ServiceModel.dll",
         "ref/netcore50/System.Windows.dll",
-        "ref/netcore50/System.Xml.dll",
         "ref/netcore50/System.Xml.Linq.dll",
         "ref/netcore50/System.Xml.Serialization.dll",
+        "ref/netcore50/System.Xml.dll",
+        "ref/netcore50/System.dll",
+        "ref/netcore50/mscorlib.dll",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/aot/lib/netcore50/mscorlib.dll",
         "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
         "runtimes/aot/lib/netcore50/System.Core.dll",
-        "runtimes/aot/lib/netcore50/System.dll",
         "runtimes/aot/lib/netcore50/System.Net.dll",
         "runtimes/aot/lib/netcore50/System.Numerics.dll",
         "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
         "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
         "runtimes/aot/lib/netcore50/System.Windows.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.dll",
         "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll"
+        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.dll",
+        "runtimes/aot/lib/netcore50/System.dll",
+        "runtimes/aot/lib/netcore50/mscorlib.dll"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.nuspec",
         "package/services/metadata/core-properties/f289de2ffef9428684eca0c193bc8765.psmdcp",
         "runtime.json"
       ]
@@ -11472,9 +11792,9 @@
       "sha512": "hoJfIl981eXwn9Tz8onO/J1xaYApIfp/YrhjSh9rRhml1U5Wj80LBgyp/6n+KI3VlvcAraThhnHnCTp+M3Uh+w==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR-arm.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.CoreCLR-arm.nuspec",
         "package/services/metadata/core-properties/c1cbeaed81514106b6b7971ac193f132.psmdcp",
         "ref/dotnet/_._",
         "runtimes/win8-arm/lib/dotnet/mscorlib.ni.dll",
@@ -11491,9 +11811,9 @@
       "sha512": "DaY5Z13xCZpnVIGluC5sCo4/0wy1rl6mptBH7v3RYi3guAmG88aSeFoQzyZepo0H0jEixUxNFM0+MB6Jc+j0bw==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR-x64.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.CoreCLR-x64.nuspec",
         "package/services/metadata/core-properties/bd7bd26b6b8242179b5b8ca3d9ffeb95.psmdcp",
         "ref/dotnet/_._",
         "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
@@ -11510,9 +11830,9 @@
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
         "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
         "ref/dotnet/_._",
         "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
@@ -11529,10 +11849,10 @@
       "sha512": "tMsWWrH1AJCguiM22zK/vr6COxqz62Q1F02B07IXAUN405R3HGk5SkD/DL0Hte+OTjNtW9LkKXpOggGBRwYFNg==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.Native.nuspec",
         "[Content_Types].xml",
         "_._",
         "_rels/.rels",
-        "Microsoft.NETCore.Runtime.Native.nuspec",
         "package/services/metadata/core-properties/a985563978b547f984c16150ef73e353.psmdcp"
       ]
     },
@@ -11540,9 +11860,9 @@
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Targets.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Targets.nuspec",
         "package/services/metadata/core-properties/5413a5ed3fde4121a1c9ee8feb12ba66.psmdcp",
         "runtime.json"
       ]
@@ -11551,9 +11871,9 @@
       "sha512": "jszcJ6okLlhqF4OQbhSbixLOuLUyVT3BP7Y7/i7fcDMwnHBd1Pmdz6M1Al9SMDKVLA2oSaItg4tq6C0ydv8lYQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.nuspec",
         "package/services/metadata/core-properties/0d18100c9f8c491492d8ddeaa9581526.psmdcp",
         "runtime.json"
       ]
@@ -11562,10 +11882,10 @@
       "sha512": "D0nsAm+yTk0oSSC7E6PcmuuEewBAQbGgIXNcCnRqQ4qLPdQLMjMHg8cilGs3xZgwTRQmMtEn45TAatrU1otWPQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.UniversalWindowsPlatform.nuspec",
         "[Content_Types].xml",
         "_._",
         "_rels/.rels",
-        "Microsoft.NETCore.UniversalWindowsPlatform.nuspec",
         "package/services/metadata/core-properties/5dffd3ce5b6640febe2db09251387062.psmdcp"
       ]
     },
@@ -11573,15 +11893,31 @@
       "sha512": "NC+dpFMdhujz2sWAdJ8EmBk07p1zOlNi0FCCnZEbzftABpw9xZ99EMP/bUJrPTgCxHfzJAiuLPOtAauzVINk0w==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Windows.ApiSets-x64.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Windows.ApiSets-x64.nuspec",
         "package/services/metadata/core-properties/b25894a2a9234c329a98dc84006b2292.psmdcp",
         "runtimes/win10-x64/native/_._",
         "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -11607,9 +11943,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-localization-l1-2-0.dll",
@@ -11623,7 +11956,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-normalization-l1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-2-0.dll",
@@ -11631,7 +11963,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-2.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-profile-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-psapi-l1-1-0.dll",
@@ -11644,13 +11975,11 @@
         "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -11675,21 +12004,12 @@
         "runtimes/win7-x64/native/api-ms-win-core-wow64-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-xstate-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-base-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-provider-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-sddl-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-service-core-l1-1-0.dll",
@@ -11700,20 +12020,13 @@
         "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
+        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win8-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win8-x64/native/api-ms-win-core-localization-l1-2-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
         "runtimes/win8-x64/native/api-ms-win-core-memory-l1-1-2.dll",
@@ -11722,33 +12035,56 @@
         "runtimes/win8-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
         "runtimes/win8-x64/native/api-ms-win-core-winrt-error-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win8-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll"
+        "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll",
+        "runtimes/win81-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x64/native/api-ms-win-security-cpwl-l1-1-0.dll"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
         "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
         "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -11774,9 +12110,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-localization-l1-2-0.dll",
@@ -11790,7 +12123,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-normalization-l1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-2-0.dll",
@@ -11798,7 +12130,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-profile-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-psapi-l1-1-0.dll",
@@ -11811,13 +12142,11 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -11842,21 +12171,12 @@
         "runtimes/win7-x86/native/api-ms-win-core-wow64-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-xstate-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-base-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-provider-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-sddl-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-service-core-l1-1-0.dll",
@@ -11867,20 +12187,13 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
+        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win8-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-localization-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-memory-l1-1-2.dll",
@@ -11889,24 +12202,32 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
         "runtimes/win8-x86/native/api-ms-win-core-winrt-error-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win8-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "Package",
       "files": [
+        "Microsoft.VisualBasic.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/Microsoft.VisualBasic.dll",
@@ -11914,16 +12235,15 @@
         "lib/netcore50/Microsoft.VisualBasic.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "Microsoft.VisualBasic.nuspec",
         "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
         "ref/dotnet/es/Microsoft.VisualBasic.xml",
         "ref/dotnet/fr/Microsoft.VisualBasic.xml",
         "ref/dotnet/it/Microsoft.VisualBasic.xml",
         "ref/dotnet/ja/Microsoft.VisualBasic.xml",
         "ref/dotnet/ko/Microsoft.VisualBasic.xml",
-        "ref/dotnet/Microsoft.VisualBasic.dll",
-        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/ru/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
@@ -11938,29 +12258,29 @@
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "Package",
       "files": [
+        "Microsoft.Win32.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/Microsoft.Win32.Primitives.dll",
         "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.Win32.Primitives.nuspec",
         "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/Microsoft.Win32.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._"
@@ -11970,6 +12290,7 @@
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "Package",
       "files": [
+        "System.AppContext.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.AppContext.dll",
@@ -11980,6 +12301,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/de/System.AppContext.xml",
         "ref/dotnet/es/System.AppContext.xml",
         "ref/dotnet/fr/System.AppContext.xml",
@@ -11987,22 +12312,18 @@
         "ref/dotnet/ja/System.AppContext.xml",
         "ref/dotnet/ko/System.AppContext.xml",
         "ref/dotnet/ru/System.AppContext.xml",
-        "ref/dotnet/System.AppContext.dll",
-        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/zh-hans/System.AppContext.xml",
         "ref/dotnet/zh-hant/System.AppContext.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.AppContext.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "Package",
       "files": [
+        "System.Collections.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Collections.dll",
@@ -12013,6 +12334,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/de/System.Collections.xml",
         "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
@@ -12020,32 +12345,32 @@
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
         "ref/dotnet/zh-hant/System.Collections.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
-        "System.Collections.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "Package",
       "files": [
+        "System.Collections.Concurrent.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
         "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
@@ -12053,45 +12378,45 @@
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.Concurrent.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
       "files": [
+        "System.Collections.Immutable.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
-        "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
-        "System.Collections.Immutable.nuspec"
+        "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "Package",
       "files": [
+        "System.Collections.NonGeneric.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Collections.NonGeneric.dll",
         "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
         "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
@@ -12099,31 +12424,31 @@
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.NonGeneric.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Collections.Specialized/4.0.0": {
       "sha512": "poJFwQCUOoXqvdoGxx+3p8Z63yawcYKPBSFP67Z2jICeOINvEIQZN7mVOAnC7gsVF0WU+A2wtVwfhagC7UCgAg==",
       "type": "Package",
       "files": [
+        "System.Collections.Specialized.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Collections.Specialized.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Collections.Specialized.dll",
         "lib/net46/System.Collections.Specialized.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/e7002e4ccd044c00a7cbd4a37efe3400.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.Specialized.dll",
+        "ref/dotnet/System.Collections.Specialized.xml",
         "ref/dotnet/de/System.Collections.Specialized.xml",
         "ref/dotnet/es/System.Collections.Specialized.xml",
         "ref/dotnet/fr/System.Collections.Specialized.xml",
@@ -12131,22 +12456,18 @@
         "ref/dotnet/ja/System.Collections.Specialized.xml",
         "ref/dotnet/ko/System.Collections.Specialized.xml",
         "ref/dotnet/ru/System.Collections.Specialized.xml",
-        "ref/dotnet/System.Collections.Specialized.dll",
-        "ref/dotnet/System.Collections.Specialized.xml",
         "ref/dotnet/zh-hans/System.Collections.Specialized.xml",
         "ref/dotnet/zh-hant/System.Collections.Specialized.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.Specialized.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "Package",
       "files": [
+        "System.ComponentModel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.ComponentModel.dll",
@@ -12156,6 +12477,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/de/System.ComponentModel.xml",
         "ref/dotnet/es/System.ComponentModel.xml",
         "ref/dotnet/fr/System.ComponentModel.xml",
@@ -12163,8 +12486,6 @@
         "ref/dotnet/ja/System.ComponentModel.xml",
         "ref/dotnet/ko/System.ComponentModel.xml",
         "ref/dotnet/ru/System.ComponentModel.xml",
-        "ref/dotnet/System.ComponentModel.dll",
-        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.xml",
         "ref/dotnet/zh-hant/System.ComponentModel.xml",
         "ref/net45/_._",
@@ -12172,23 +12493,27 @@
         "ref/netcore50/System.ComponentModel.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.ComponentModel.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "Package",
       "files": [
+        "System.ComponentModel.Annotations.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/de/System.ComponentModel.Annotations.xml",
         "ref/dotnet/es/System.ComponentModel.Annotations.xml",
         "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
@@ -12196,31 +12521,31 @@
         "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/System.ComponentModel.Annotations.dll",
-        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ComponentModel.Annotations.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "Package",
       "files": [
+        "System.ComponentModel.EventBasedAsync.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
@@ -12228,31 +12553,31 @@
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ComponentModel.EventBasedAsync.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Data.Common/4.0.0": {
       "sha512": "SA7IdoTWiImVr0exDM68r0mKmR4f/qFGxZUrJQKu4YS7F+3afWzSOCezHxWdevQ0ONi4WRQsOiv+Zf9p8H0Feg==",
       "type": "Package",
       "files": [
+        "System.Data.Common.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Data.Common.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Data.Common.dll",
         "lib/net46/System.Data.Common.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/aa5ad20c33d94c8e8016ba4fc64d8d66.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Data.Common.dll",
+        "ref/dotnet/System.Data.Common.xml",
         "ref/dotnet/de/System.Data.Common.xml",
         "ref/dotnet/es/System.Data.Common.xml",
         "ref/dotnet/fr/System.Data.Common.xml",
@@ -12260,22 +12585,18 @@
         "ref/dotnet/ja/System.Data.Common.xml",
         "ref/dotnet/ko/System.Data.Common.xml",
         "ref/dotnet/ru/System.Data.Common.xml",
-        "ref/dotnet/System.Data.Common.dll",
-        "ref/dotnet/System.Data.Common.xml",
         "ref/dotnet/zh-hans/System.Data.Common.xml",
         "ref/dotnet/zh-hant/System.Data.Common.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Data.Common.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Data.Common.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Contracts.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
@@ -12285,6 +12606,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
         "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
@@ -12292,8 +12615,6 @@
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
@@ -12302,14 +12623,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
-        "System.Diagnostics.Contracts.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Debug.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
@@ -12320,6 +12641,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
         "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
@@ -12327,23 +12652,19 @@
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
-        "System.Diagnostics.Debug.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.StackTrace.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
@@ -12354,6 +12675,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/de/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/fr/System.Diagnostics.StackTrace.xml",
@@ -12361,23 +12686,19 @@
         "ref/dotnet/ja/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ko/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ru/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "System.Diagnostics.StackTrace.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Tools.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
@@ -12387,6 +12708,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
         "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
@@ -12394,8 +12717,6 @@
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
@@ -12404,14 +12725,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
-        "System.Diagnostics.Tools.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Tracing.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
@@ -12422,6 +12743,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
         "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
@@ -12429,23 +12754,19 @@
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
-        "System.Diagnostics.Tracing.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "Package",
       "files": [
+        "System.Dynamic.Runtime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
@@ -12456,6 +12777,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/de/System.Dynamic.Runtime.xml",
         "ref/dotnet/es/System.Dynamic.Runtime.xml",
         "ref/dotnet/fr/System.Dynamic.Runtime.xml",
@@ -12463,24 +12788,20 @@
         "ref/dotnet/ja/System.Dynamic.Runtime.xml",
         "ref/dotnet/ko/System.Dynamic.Runtime.xml",
         "ref/dotnet/ru/System.Dynamic.Runtime.xml",
-        "ref/dotnet/System.Dynamic.Runtime.dll",
-        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
-        "System.Dynamic.Runtime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "Package",
       "files": [
+        "System.Globalization.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Globalization.dll",
@@ -12491,6 +12812,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/de/System.Globalization.xml",
         "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
@@ -12498,23 +12823,19 @@
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
         "ref/dotnet/zh-hant/System.Globalization.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
-        "System.Globalization.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "Package",
       "files": [
+        "System.Globalization.Calendars.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
@@ -12525,6 +12846,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
         "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
@@ -12532,32 +12857,32 @@
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "System.Globalization.Calendars.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "Package",
       "files": [
+        "System.Globalization.Extensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Globalization.Extensions.dll",
         "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
         "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
@@ -12565,22 +12890,18 @@
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Globalization.Extensions.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "Package",
       "files": [
+        "System.IO.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.IO.dll",
@@ -12591,6 +12912,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/de/System.IO.xml",
         "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
@@ -12598,28 +12923,24 @@
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
         "ref/dotnet/zh-hant/System.IO.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
-        "System.IO.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.IO.Compression.dll",
         "lib/net45/_._",
         "lib/netcore50/System.IO.Compression.dll",
         "lib/win8/_._",
@@ -12627,6 +12948,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/de/System.IO.Compression.xml",
         "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
@@ -12634,12 +12959,8 @@
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
         "ref/dotnet/zh-hant/System.IO.Compression.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/netcore50/System.IO.Compression.dll",
         "ref/netcore50/System.IO.Compression.xml",
@@ -12647,59 +12968,63 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.IO.Compression.nuspec"
+        "runtime.json"
       ]
     },
     "System.IO.Compression.clrcompression-arm/4.0.0": {
       "sha512": "Kk21GecAbI+H6tMP6/lMssGObbhoHwLiREiB5UkNMCypdxACuF+6gmrdDTousCUcbH28CJeo7tArrnUc+bchuw==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.clrcompression-arm.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "package/services/metadata/core-properties/e09228dcfd7b47adb2ddcf73e2eb6ddf.psmdcp",
         "runtimes/win10-arm/native/ClrCompression.dll",
-        "runtimes/win7-arm/native/clrcompression.dll",
-        "System.IO.Compression.clrcompression-arm.nuspec"
+        "runtimes/win7-arm/native/clrcompression.dll"
       ]
     },
     "System.IO.Compression.clrcompression-x64/4.0.0": {
       "sha512": "Lqr+URMwKzf+8HJF6YrqEqzKzDzFJTE4OekaxqdIns71r8Ufbd8SbZa0LKl9q+7nu6Em4SkIEXVMB7plSXekOw==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.clrcompression-x64.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "package/services/metadata/core-properties/416c3fd9fab749d484e0fed458de199f.psmdcp",
         "runtimes/win10-x64/native/ClrCompression.dll",
-        "runtimes/win7-x64/native/clrcompression.dll",
-        "System.IO.Compression.clrcompression-x64.nuspec"
+        "runtimes/win7-x64/native/clrcompression.dll"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.clrcompression-x86.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "package/services/metadata/core-properties/cd12f86c8cc2449589dfbe349763f7b3.psmdcp",
         "runtimes/win10-x86/native/ClrCompression.dll",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "System.IO.Compression.clrcompression-x86.nuspec"
+        "runtimes/win7-x86/native/clrcompression.dll"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.ZipFile.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.IO.Compression.ZipFile.dll",
         "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
@@ -12707,22 +13032,18 @@
         "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.Compression.ZipFile.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "Package",
       "files": [
+        "System.IO.FileSystem.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.IO.FileSystem.dll",
@@ -12733,6 +13054,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/de/System.IO.FileSystem.xml",
         "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
@@ -12740,31 +13065,31 @@
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.FileSystem.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "Package",
       "files": [
+        "System.IO.FileSystem.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
         "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
@@ -12772,22 +13097,18 @@
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.FileSystem.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO.IsolatedStorage/4.0.0": {
       "sha512": "d5KimUbZ49Ki6A/uwU+Iodng+nhJvpRs7hr/828cfeXC02LxUiggnRnAu+COtWcKvJ2YbBmAGOcO4GLK4fX1+w==",
       "type": "Package",
       "files": [
+        "System.IO.IsolatedStorage.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/MonoAndroid10/_._",
@@ -12796,6 +13117,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/0d69e649eab84c3cad77d63bb460f7e7.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.IsolatedStorage.dll",
+        "ref/dotnet/System.IO.IsolatedStorage.xml",
         "ref/dotnet/de/System.IO.IsolatedStorage.xml",
         "ref/dotnet/es/System.IO.IsolatedStorage.xml",
         "ref/dotnet/fr/System.IO.IsolatedStorage.xml",
@@ -12803,30 +13128,30 @@
         "ref/dotnet/ja/System.IO.IsolatedStorage.xml",
         "ref/dotnet/ko/System.IO.IsolatedStorage.xml",
         "ref/dotnet/ru/System.IO.IsolatedStorage.xml",
-        "ref/dotnet/System.IO.IsolatedStorage.dll",
-        "ref/dotnet/System.IO.IsolatedStorage.xml",
         "ref/dotnet/zh-hans/System.IO.IsolatedStorage.xml",
         "ref/dotnet/zh-hant/System.IO.IsolatedStorage.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.IsolatedStorage.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "Package",
       "files": [
+        "System.IO.UnmanagedMemoryStream.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
         "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
@@ -12834,22 +13159,18 @@
         "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.UnmanagedMemoryStream.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
       "files": [
+        "System.Linq.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Linq.dll",
@@ -12859,6 +13180,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/de/System.Linq.xml",
         "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
@@ -12866,8 +13189,6 @@
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
         "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
@@ -12875,14 +13196,14 @@
         "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Linq.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "Package",
       "files": [
+        "System.Linq.Expressions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Linq.Expressions.dll",
@@ -12893,6 +13214,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/de/System.Linq.Expressions.xml",
         "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
@@ -12900,24 +13225,20 @@
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
-        "System.Linq.Expressions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "Package",
       "files": [
+        "System.Linq.Parallel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Linq.Parallel.dll",
@@ -12926,6 +13247,8 @@
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/de/System.Linq.Parallel.xml",
         "ref/dotnet/es/System.Linq.Parallel.xml",
         "ref/dotnet/fr/System.Linq.Parallel.xml",
@@ -12933,22 +13256,20 @@
         "ref/dotnet/ja/System.Linq.Parallel.xml",
         "ref/dotnet/ko/System.Linq.Parallel.xml",
         "ref/dotnet/ru/System.Linq.Parallel.xml",
-        "ref/dotnet/System.Linq.Parallel.dll",
-        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Linq.Parallel.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "Package",
       "files": [
+        "System.Linq.Queryable.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Linq.Queryable.dll",
@@ -12958,6 +13279,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/de/System.Linq.Queryable.xml",
         "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
@@ -12965,8 +13288,6 @@
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
@@ -12974,14 +13295,14 @@
         "ref/netcore50/System.Linq.Queryable.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Linq.Queryable.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "Package",
       "files": [
+        "System.Net.Http.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Net.Http.dll",
@@ -12990,6 +13311,8 @@
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/de/System.Net.Http.xml",
         "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
@@ -12997,27 +13320,27 @@
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
         "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Net.Http.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Net.Http.Rtc/4.0.0": {
       "sha512": "PlE+oJgXdbxPmZYR6GBywRkyIPovjB1Y0SYHizj2Iflgu80uJQC4szl9gue4rKI2FgXiEbj9JL7wL5K3mp9HAQ==",
       "type": "Package",
       "files": [
+        "System.Net.Http.Rtc.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/netcore50/System.Net.Http.Rtc.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/5ae6b04142264f2abb319c7dccbfb69f.psmdcp",
+        "ref/dotnet/System.Net.Http.Rtc.dll",
+        "ref/dotnet/System.Net.Http.Rtc.xml",
         "ref/dotnet/de/System.Net.Http.Rtc.xml",
         "ref/dotnet/es/System.Net.Http.Rtc.xml",
         "ref/dotnet/fr/System.Net.Http.Rtc.xml",
@@ -13025,20 +13348,18 @@
         "ref/dotnet/ja/System.Net.Http.Rtc.xml",
         "ref/dotnet/ko/System.Net.Http.Rtc.xml",
         "ref/dotnet/ru/System.Net.Http.Rtc.xml",
-        "ref/dotnet/System.Net.Http.Rtc.dll",
-        "ref/dotnet/System.Net.Http.Rtc.xml",
         "ref/dotnet/zh-hans/System.Net.Http.Rtc.xml",
         "ref/dotnet/zh-hant/System.Net.Http.Rtc.xml",
         "ref/netcore50/System.Net.Http.Rtc.dll",
         "ref/netcore50/System.Net.Http.Rtc.xml",
-        "ref/win8/_._",
-        "System.Net.Http.Rtc.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "Package",
       "files": [
+        "System.Net.NetworkInformation.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/MonoAndroid10/_._",
@@ -13051,6 +13372,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
         "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
@@ -13058,12 +13383,8 @@
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/netcore50/System.Net.NetworkInformation.dll",
         "ref/netcore50/System.Net.NetworkInformation.xml",
@@ -13071,14 +13392,14 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.NetworkInformation.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "Package",
       "files": [
+        "System.Net.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Net.Primitives.dll",
@@ -13089,6 +13410,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/de/System.Net.Primitives.xml",
         "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
@@ -13096,31 +13421,31 @@
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
         "ref/dotnet/zh-hant/System.Net.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Net.Requests/4.0.10": {
       "sha512": "A6XBR7TztiIQg6hx7VGfbBKmRTAavUERm2E7pmNz/gZeGvwyP0lcKHZxylJtNVKj7DPwr91bD87oLY6zZYntcg==",
       "type": "Package",
       "files": [
+        "System.Net.Requests.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Net.Requests.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Net.Requests.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/7a4e397882e44db3aa06d6d8c9dd3d66.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.Requests.dll",
+        "ref/dotnet/System.Net.Requests.xml",
         "ref/dotnet/de/System.Net.Requests.xml",
         "ref/dotnet/es/System.Net.Requests.xml",
         "ref/dotnet/fr/System.Net.Requests.xml",
@@ -13128,22 +13453,18 @@
         "ref/dotnet/ja/System.Net.Requests.xml",
         "ref/dotnet/ko/System.Net.Requests.xml",
         "ref/dotnet/ru/System.Net.Requests.xml",
-        "ref/dotnet/System.Net.Requests.dll",
-        "ref/dotnet/System.Net.Requests.xml",
         "ref/dotnet/zh-hans/System.Net.Requests.xml",
         "ref/dotnet/zh-hant/System.Net.Requests.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Requests.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Net.Sockets/4.0.0": {
       "sha512": "7bBNLdO6Xw0BGyFVSxjloGXMvsc3qQmW+70bYMLwHEAVivMK8zx+E7XO8CeJnAko2mFj6R402E798EGYUksFcQ==",
       "type": "Package",
       "files": [
+        "System.Net.Sockets.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/MonoAndroid10/_._",
@@ -13153,6 +13474,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/cca33bc0996f49c68976fa5bab1500ff.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.Sockets.dll",
+        "ref/dotnet/System.Net.Sockets.xml",
         "ref/dotnet/de/System.Net.Sockets.xml",
         "ref/dotnet/es/System.Net.Sockets.xml",
         "ref/dotnet/fr/System.Net.Sockets.xml",
@@ -13160,31 +13485,31 @@
         "ref/dotnet/ja/System.Net.Sockets.xml",
         "ref/dotnet/ko/System.Net.Sockets.xml",
         "ref/dotnet/ru/System.Net.Sockets.xml",
-        "ref/dotnet/System.Net.Sockets.dll",
-        "ref/dotnet/System.Net.Sockets.xml",
         "ref/dotnet/zh-hans/System.Net.Sockets.xml",
         "ref/dotnet/zh-hant/System.Net.Sockets.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Sockets.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Sockets.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Net.WebHeaderCollection/4.0.0": {
       "sha512": "IsIZAsHm/yK7R/XASnEc4EMffFLIMgYchG3/zJv6B4LwMnXZwrVlSPpNbPgEVb0lSXyztsn7A6sIPAACQQ2vTQ==",
       "type": "Package",
       "files": [
+        "System.Net.WebHeaderCollection.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Net.WebHeaderCollection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Net.WebHeaderCollection.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/7ab0d7bde19b47548622bfa222a4eccb.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Net.WebHeaderCollection.dll",
+        "ref/dotnet/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/de/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/es/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/fr/System.Net.WebHeaderCollection.xml",
@@ -13192,64 +13517,64 @@
         "ref/dotnet/ja/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/ko/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/ru/System.Net.WebHeaderCollection.xml",
-        "ref/dotnet/System.Net.WebHeaderCollection.dll",
-        "ref/dotnet/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/zh-hans/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/zh-hant/System.Net.WebHeaderCollection.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.WebHeaderCollection.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "Package",
       "files": [
+        "System.Numerics.Vectors.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Numerics.Vectors.dll",
         "lib/net46/System.Numerics.Vectors.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
-        "ref/dotnet/System.Numerics.Vectors.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Numerics.Vectors.dll",
         "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Numerics.Vectors.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
       "sha512": "Ly7GvoPFZq6GyfZpfS0E7uCk1cinl5BANAngXVuau3lD2QqZJMHitzlPv6n1FlIn6krfv99X2IPkIaVzUwDHXA==",
       "type": "Package",
       "files": [
+        "System.Numerics.Vectors.WindowsRuntime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll",
-        "package/services/metadata/core-properties/6db0e2464a274e8eb688cd193eb37876.psmdcp",
-        "System.Numerics.Vectors.WindowsRuntime.nuspec"
+        "package/services/metadata/core-properties/6db0e2464a274e8eb688cd193eb37876.psmdcp"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "Package",
       "files": [
+        "System.ObjectModel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.ObjectModel.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/de/System.ObjectModel.xml",
         "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
@@ -13257,22 +13582,18 @@
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
         "ref/dotnet/zh-hant/System.ObjectModel.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ObjectModel.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Private.DataContractSerialization/4.0.0": {
       "sha512": "uQvzoXHXHn/9YqUmPtgD8ZPJIlBuuL3QHegbuik97W/umoI28fOnGLnvjRHhju1VMWvFLRQoh7uZkBaoZ+KpVQ==",
       "type": "Package",
       "files": [
+        "System.Private.DataContractSerialization.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Private.DataContractSerialization.dll",
@@ -13281,42 +13602,42 @@
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
-        "System.Private.DataContractSerialization.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "Package",
       "files": [
+        "System.Private.Networking.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._",
-        "System.Private.Networking.nuspec"
+        "ref/netcore50/_._"
       ]
     },
     "System.Private.ServiceModel/4.0.0": {
       "sha512": "cm2wEa1f9kuUq/2k8uIwepgZJi5HdxXSnjGQIeXmAb7RaWfZPEC/iamv9GJ67b5LPnCZHR0KvtFqh82e8AAYSw==",
       "type": "Package",
       "files": [
+        "System.Private.ServiceModel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "package/services/metadata/core-properties/5668af7c10764fafb51182a583dfb872.psmdcp",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._",
-        "System.Private.ServiceModel.nuspec"
+        "ref/netcore50/_._"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "Package",
       "files": [
+        "System.Private.Uri.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Private.Uri.dll",
@@ -13324,14 +13645,14 @@
         "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "System.Private.Uri.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "Package",
       "files": [
+        "System.Reflection.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.dll",
@@ -13342,6 +13663,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/de/System.Reflection.xml",
         "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
@@ -13349,29 +13674,27 @@
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
         "ref/dotnet/zh-hant/System.Reflection.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
-        "System.Reflection.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
       ]
     },
     "System.Reflection.Context/4.0.0": {
       "sha512": "Gz4sUHHFd/52RjHccSHbOXdujJEWKfL3gIaA+ekxvQaQfJGbI2tPzA0Uv3WTCTDRGHgtoNq5WS9E007Dt4P/VQ==",
       "type": "Package",
       "files": [
+        "System.Reflection.Context.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Context.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/263ca61f1b594d9395e210a55a8fe7a7.psmdcp",
+        "ref/dotnet/System.Reflection.Context.dll",
+        "ref/dotnet/System.Reflection.Context.xml",
         "ref/dotnet/de/System.Reflection.Context.xml",
         "ref/dotnet/es/System.Reflection.Context.xml",
         "ref/dotnet/fr/System.Reflection.Context.xml",
@@ -13379,21 +13702,19 @@
         "ref/dotnet/ja/System.Reflection.Context.xml",
         "ref/dotnet/ko/System.Reflection.Context.xml",
         "ref/dotnet/ru/System.Reflection.Context.xml",
-        "ref/dotnet/System.Reflection.Context.dll",
-        "ref/dotnet/System.Reflection.Context.xml",
         "ref/dotnet/zh-hans/System.Reflection.Context.xml",
         "ref/dotnet/zh-hant/System.Reflection.Context.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Reflection.Context.dll",
         "ref/netcore50/System.Reflection.Context.xml",
-        "ref/win8/_._",
-        "System.Reflection.Context.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "Package",
       "files": [
+        "System.Reflection.DispatchProxy.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
@@ -13404,6 +13725,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
@@ -13411,23 +13736,19 @@
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
-        "System.Reflection.DispatchProxy.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "Package",
       "files": [
+        "System.Reflection.Emit.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Emit.dll",
@@ -13436,6 +13757,9 @@
         "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/de/System.Reflection.Emit.xml",
         "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
@@ -13443,20 +13767,17 @@
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
-        "ref/MonoAndroid10/_._",
         "ref/net45/_._",
-        "ref/xamarinmac20/_._",
-        "System.Reflection.Emit.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "Package",
       "files": [
+        "System.Reflection.Emit.ILGeneration.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
@@ -13464,6 +13785,8 @@
         "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
         "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
@@ -13471,19 +13794,17 @@
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
-        "ref/wp80/_._",
-        "System.Reflection.Emit.ILGeneration.nuspec"
+        "ref/wp80/_._"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "Package",
       "files": [
+        "System.Reflection.Emit.Lightweight.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
@@ -13491,6 +13812,8 @@
         "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/wp80/_._",
         "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
@@ -13498,19 +13821,17 @@
         "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
-        "ref/wp80/_._",
-        "System.Reflection.Emit.Lightweight.nuspec"
+        "ref/wp80/_._"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "Package",
       "files": [
+        "System.Reflection.Extensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
@@ -13520,6 +13841,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
         "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
@@ -13527,8 +13850,6 @@
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
@@ -13537,28 +13858,28 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
-        "System.Reflection.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
       ]
     },
     "System.Reflection.Metadata/1.0.22": {
       "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
       "type": "Package",
       "files": [
+        "System.Reflection.Metadata.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Reflection.Metadata.dll",
         "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
-        "System.Reflection.Metadata.nuspec"
+        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "Package",
       "files": [
+        "System.Reflection.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
@@ -13568,6 +13889,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
         "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
@@ -13575,8 +13898,6 @@
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
@@ -13585,14 +13906,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
-        "System.Reflection.Primitives.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "Package",
       "files": [
+        "System.Reflection.TypeExtensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
@@ -13603,6 +13924,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
@@ -13610,23 +13935,19 @@
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "System.Reflection.TypeExtensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "Package",
       "files": [
+        "System.Resources.ResourceManager.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
@@ -13636,6 +13957,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
         "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
@@ -13643,8 +13966,6 @@
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
@@ -13653,14 +13974,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
-        "System.Resources.ResourceManager.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "Package",
       "files": [
+        "System.Runtime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.dll",
@@ -13671,6 +13992,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/de/System.Runtime.xml",
         "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
@@ -13678,23 +14003,19 @@
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
         "ref/dotnet/zh-hant/System.Runtime.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "Package",
       "files": [
+        "System.Runtime.Extensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
@@ -13705,6 +14026,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
         "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
@@ -13712,23 +14037,19 @@
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
-        "System.Runtime.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "Package",
       "files": [
+        "System.Runtime.Handles.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Handles.dll",
@@ -13739,6 +14060,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/de/System.Runtime.Handles.xml",
         "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
@@ -13746,23 +14071,19 @@
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
-        "System.Runtime.Handles.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "Package",
       "files": [
+        "System.Runtime.InteropServices.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
@@ -13773,6 +14094,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
         "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
@@ -13780,23 +14105,19 @@
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
-        "System.Runtime.InteropServices.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
       ]
     },
     "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
       "sha512": "K5MGSvw/sGPKQYdOVqSpsVbHBE8HccHIDEhUNjM1lui65KGF/slNZfijGU87ggQiVXTI802ebKiOYBkwiLotow==",
       "type": "Package",
       "files": [
+        "System.Runtime.InteropServices.WindowsRuntime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/net45/_._",
@@ -13805,6 +14126,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/3c944c6b4d6044d28ee80e49a09300c9.psmdcp",
+        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/de/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/es/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.WindowsRuntime.xml",
@@ -13812,8 +14135,6 @@
         "ref/dotnet/ja/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.WindowsRuntime.xml",
-        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.dll",
-        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/dotnet/zh-hant/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/net45/_._",
@@ -13822,14 +14143,14 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
-        "System.Runtime.InteropServices.WindowsRuntime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "Package",
       "files": [
+        "System.Runtime.Numerics.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Runtime.Numerics.dll",
@@ -13838,6 +14159,8 @@
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
         "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
@@ -13845,22 +14168,20 @@
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Runtime.Numerics.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Runtime.Serialization.Json/4.0.0": {
       "sha512": "emhWMQP3sdtkAhD0TOeP3FfjS57sfQMQ2sqA6f2Yj5Gd9jkHV4KsQ2TsoJjghca6d8fur7+REQ6ILBXVdGf/0g==",
       "type": "Package",
       "files": [
+        "System.Runtime.Serialization.Json.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Serialization.Json.dll",
@@ -13870,6 +14191,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/2c520ff333ad4bde986eb7a015ba6343.psmdcp",
+        "ref/dotnet/System.Runtime.Serialization.Json.dll",
+        "ref/dotnet/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/de/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/es/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/fr/System.Runtime.Serialization.Json.xml",
@@ -13877,8 +14200,6 @@
         "ref/dotnet/ja/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/ko/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/ru/System.Runtime.Serialization.Json.xml",
-        "ref/dotnet/System.Runtime.Serialization.Json.dll",
-        "ref/dotnet/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/zh-hans/System.Runtime.Serialization.Json.xml",
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Json.xml",
         "ref/net45/_._",
@@ -13887,23 +14208,27 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll",
-        "System.Runtime.Serialization.Json.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll"
       ]
     },
     "System.Runtime.Serialization.Primitives/4.0.10": {
       "sha512": "NPc8DZIomf5tGjYtz/KTHI01IPcVlypfhCux32AbLPDjTotdvL8TpKRwMyQJ6Kh08yprRVH7uBD1PdJiuoFzag==",
       "type": "Package",
       "files": [
+        "System.Runtime.Serialization.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/92e70054da8743d68462736e85fe5580.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/de/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/es/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/fr/System.Runtime.Serialization.Primitives.xml",
@@ -13911,22 +14236,18 @@
         "ref/dotnet/ja/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/ko/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/ru/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
-        "ref/dotnet/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/zh-hans/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Runtime.Serialization.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Runtime.Serialization.Xml/4.0.10": {
       "sha512": "xsy7XbH8RTpKoDPNcibSGCOpujsmwUmOWAby3PssqkZFpLBXUbDO2s6JKITRjxejET2g0PK8t+mdIvu3xmUuKA==",
       "type": "Package",
       "files": [
+        "System.Runtime.Serialization.Xml.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
@@ -13937,6 +14258,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/7d99189e9ae248c9a98d9fc3ccdc5130.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Serialization.Xml.dll",
+        "ref/dotnet/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/de/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/es/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/fr/System.Runtime.Serialization.Xml.xml",
@@ -13944,29 +14269,27 @@
         "ref/dotnet/ja/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/ko/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/ru/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/System.Runtime.Serialization.Xml.dll",
-        "ref/dotnet/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/zh-hans/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Xml.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
-        "System.Runtime.Serialization.Xml.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll"
       ]
     },
     "System.Runtime.WindowsRuntime/4.0.10": {
       "sha512": "9w6ypdnEw8RrLRlxTbLAYrap4eL1xIQeNoOaumQVOQ8TTD/5g9FGrBtY3KLiGxAPieN9AwAAEIDkugU85Cwuvg==",
       "type": "Package",
       "files": [
+        "System.Runtime.WindowsRuntime.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/netcore50/System.Runtime.WindowsRuntime.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/a81cabb2b7e843ce801ecf91886941d4.psmdcp",
+        "ref/dotnet/System.Runtime.WindowsRuntime.dll",
+        "ref/dotnet/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/de/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/es/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/fr/System.Runtime.WindowsRuntime.xml",
@@ -13974,28 +14297,28 @@
         "ref/dotnet/ja/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/ko/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/ru/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/System.Runtime.WindowsRuntime.dll",
-        "ref/dotnet/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/zh-hans/System.Runtime.WindowsRuntime.xml",
         "ref/dotnet/zh-hant/System.Runtime.WindowsRuntime.xml",
         "ref/netcore50/System.Runtime.WindowsRuntime.dll",
         "ref/netcore50/System.Runtime.WindowsRuntime.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll",
-        "System.Runtime.WindowsRuntime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll"
       ]
     },
     "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
       "sha512": "2GY3fkXBMQOyyO9ovaH46CN6MD2ck/Gvk4VNAgVDvtmfO3HXYFNd+bB05WhVcJrHKbfKZNwfwZKpYZ+OsVFsLw==",
       "type": "Package",
       "files": [
+        "System.Runtime.WindowsRuntime.UI.Xaml.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/0f3b84a81b7a4a97aa765ed058bf6c20.psmdcp",
+        "ref/dotnet/System.Runtime.WindowsRuntime.UI.Xaml.dll",
+        "ref/dotnet/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/de/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/es/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/fr/System.Runtime.WindowsRuntime.UI.Xaml.xml",
@@ -14003,30 +14326,32 @@
         "ref/dotnet/ja/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/ko/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/ru/System.Runtime.WindowsRuntime.UI.Xaml.xml",
-        "ref/dotnet/System.Runtime.WindowsRuntime.UI.Xaml.dll",
-        "ref/dotnet/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/zh-hans/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/dotnet/zh-hant/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Runtime.WindowsRuntime.UI.Xaml.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "Package",
       "files": [
+        "System.Security.Claims.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Security.Claims.dll",
         "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/de/System.Security.Claims.xml",
         "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
@@ -14034,22 +14359,18 @@
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
         "ref/dotnet/zh-hant/System.Security.Claims.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Claims.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "Package",
       "files": [
+        "System.Security.Principal.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Security.Principal.dll",
@@ -14059,6 +14380,8 @@
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/de/System.Security.Principal.xml",
         "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
@@ -14066,8 +14389,6 @@
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
         "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
@@ -14075,14 +14396,14 @@
         "ref/netcore50/System.Security.Principal.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Security.Principal.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.ServiceModel.Duplex/4.0.0": {
       "sha512": "JFeDn+IsiwAVJkNNnM7MLefJOnzYhovaHnjk3lzEnUWkYZJeAKrcgLdK6GE2GNjb5mEV8Pad/E0JcA8eCr3eWQ==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.Duplex.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
@@ -14090,6 +14411,8 @@
         "lib/netcore50/System.ServiceModel.Duplex.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/8a542ab34ffb4a13958ce3d7279d9dae.psmdcp",
+        "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
         "ref/dotnet/de/System.ServiceModel.Duplex.xml",
         "ref/dotnet/es/System.ServiceModel.Duplex.xml",
         "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
@@ -14097,21 +14420,19 @@
         "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
         "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
         "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
-        "ref/dotnet/System.ServiceModel.Duplex.dll",
-        "ref/dotnet/System.ServiceModel.Duplex.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/netcore50/System.ServiceModel.Duplex.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.Duplex.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.ServiceModel.Http/4.0.10": {
       "sha512": "Vyl7lmvMlXJamtnDugoXuAgAQGSqtA7omK3zDBYByhbYeBC2hRBchgyXox7e5vEO+29TeB1IpoLWQGb7tO9h6A==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.Http.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.Http.dll",
@@ -14122,6 +14443,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/da6bab8a73fb4ac9af198a5f70d8aa64.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
         "ref/dotnet/de/System.ServiceModel.Http.xml",
         "ref/dotnet/es/System.ServiceModel.Http.xml",
         "ref/dotnet/fr/System.ServiceModel.Http.xml",
@@ -14129,22 +14454,18 @@
         "ref/dotnet/ja/System.ServiceModel.Http.xml",
         "ref/dotnet/ko/System.ServiceModel.Http.xml",
         "ref/dotnet/ru/System.ServiceModel.Http.xml",
-        "ref/dotnet/System.ServiceModel.Http.dll",
-        "ref/dotnet/System.ServiceModel.Http.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.ServiceModel.NetTcp/4.0.0": {
       "sha512": "lV2Cdcso9jOS0KBtgHZHzTLe/Lx/ERdPcvF4dlepUie6/+BOMYTOgg2C7OdpIjp3fwUNXq8nhU+IilmEyjuf/A==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.NetTcp.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
@@ -14152,6 +14473,8 @@
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/024bb3a15d5444e2b8b485ce4cf44640.psmdcp",
+        "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
@@ -14159,21 +14482,19 @@
         "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
-        "ref/dotnet/System.ServiceModel.NetTcp.dll",
-        "ref/dotnet/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/netcore50/System.ServiceModel.NetTcp.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.NetTcp.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.ServiceModel.Primitives/4.0.0": {
       "sha512": "uF5VYQWR07LgiZkzUr8qjwvqOaIAfwU566MneD4WuC14d8FLJNsAgCJUYhBGB7COjH7HTqnP9ZFmr6c+L83Stg==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.Primitives.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
@@ -14181,6 +14502,8 @@
         "lib/netcore50/System.ServiceModel.Primitives.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/551694f534894508bee57aba617484c9.psmdcp",
+        "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
         "ref/dotnet/de/System.ServiceModel.Primitives.xml",
         "ref/dotnet/es/System.ServiceModel.Primitives.xml",
         "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
@@ -14188,21 +14511,19 @@
         "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
         "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
         "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
-        "ref/dotnet/System.ServiceModel.Primitives.dll",
-        "ref/dotnet/System.ServiceModel.Primitives.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/netcore50/System.ServiceModel.Primitives.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.Primitives.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.ServiceModel.Security/4.0.0": {
       "sha512": "sPVzsnd8w/TJsW/4sYA9eIGP+RtlpN0AhKLGKf9ywdGGmHPi0kkuX2mx412dM3GN0e4oifuISwvZqby/sI8Feg==",
       "type": "Package",
       "files": [
+        "System.ServiceModel.Security.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.ServiceModel.Security.dll",
@@ -14210,6 +14531,8 @@
         "lib/netcore50/System.ServiceModel.Security.dll",
         "lib/win8/_._",
         "package/services/metadata/core-properties/724a153019f4439f95c814a98c7503f4.psmdcp",
+        "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
         "ref/dotnet/de/System.ServiceModel.Security.xml",
         "ref/dotnet/es/System.ServiceModel.Security.xml",
         "ref/dotnet/fr/System.ServiceModel.Security.xml",
@@ -14217,21 +14540,19 @@
         "ref/dotnet/ja/System.ServiceModel.Security.xml",
         "ref/dotnet/ko/System.ServiceModel.Security.xml",
         "ref/dotnet/ru/System.ServiceModel.Security.xml",
-        "ref/dotnet/System.ServiceModel.Security.dll",
-        "ref/dotnet/System.ServiceModel.Security.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/netcore50/System.ServiceModel.Security.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.Security.nuspec"
+        "ref/win8/_._"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "Package",
       "files": [
+        "System.Text.Encoding.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Text.Encoding.dll",
@@ -14242,6 +14563,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/de/System.Text.Encoding.xml",
         "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
@@ -14249,31 +14574,31 @@
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
-        "System.Text.Encoding.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
       ]
     },
     "System.Text.Encoding.CodePages/4.0.0": {
       "sha512": "ZHBTr1AXLjY9OuYR7pKx5xfN6QFye1kgd5QAbGrvfCOu7yxRnJs3VUaxERe1fOlnF0mi/xD/Dvb3T3x3HNuPWQ==",
       "type": "Package",
       "files": [
+        "System.Text.Encoding.CodePages.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Text.Encoding.CodePages.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Text.Encoding.CodePages.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/8a616349cf5c4e6ba7634969c080759b.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.Encoding.CodePages.dll",
+        "ref/dotnet/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/de/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/es/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/fr/System.Text.Encoding.CodePages.xml",
@@ -14281,21 +14606,17 @@
         "ref/dotnet/ja/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/ko/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/ru/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/System.Text.Encoding.CodePages.dll",
-        "ref/dotnet/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.CodePages.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Text.Encoding.CodePages.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "Package",
       "files": [
+        "System.Text.Encoding.Extensions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
@@ -14306,6 +14627,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
@@ -14313,32 +14638,32 @@
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
-        "System.Text.Encoding.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "Package",
       "files": [
+        "System.Text.RegularExpressions.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
         "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
@@ -14346,22 +14671,18 @@
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Text.RegularExpressions.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "Package",
       "files": [
+        "System.Threading.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Threading.dll",
@@ -14372,6 +14693,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/de/System.Threading.xml",
         "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
@@ -14379,29 +14704,27 @@
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
         "ref/dotnet/zh-hant/System.Threading.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
-        "System.Threading.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "Package",
       "files": [
+        "System.Threading.Overlapped.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
         "lib/netcore50/System.Threading.Overlapped.dll",
         "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
         "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
@@ -14409,18 +14732,16 @@
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
-        "ref/net46/System.Threading.Overlapped.dll",
-        "System.Threading.Overlapped.nuspec"
+        "ref/net46/System.Threading.Overlapped.dll"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "Package",
       "files": [
+        "System.Threading.Tasks.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Threading.Tasks.dll",
@@ -14431,6 +14752,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/de/System.Threading.Tasks.xml",
         "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
@@ -14438,39 +14763,35 @@
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
-        "System.Threading.Tasks.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "Package",
       "files": [
+        "System.Threading.Tasks.Dataflow.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp",
-        "System.Threading.Tasks.Dataflow.nuspec"
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "Package",
       "files": [
+        "System.Threading.Tasks.Parallel.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
@@ -14479,6 +14800,8 @@
         "lib/win8/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
@@ -14486,22 +14809,20 @@
         "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
-        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Threading.Tasks.Parallel.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "Package",
       "files": [
+        "System.Threading.Timer.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Threading.Timer.dll",
@@ -14510,6 +14831,8 @@
         "lib/win81/_._",
         "lib/wpa81/_._",
         "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/de/System.Threading.Timer.xml",
         "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
@@ -14517,8 +14840,6 @@
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
         "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
@@ -14526,23 +14847,27 @@
         "ref/netcore50/System.Threading.Timer.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
-        "System.Threading.Timer.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "Package",
       "files": [
+        "System.Xml.ReaderWriter.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
         "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
@@ -14550,31 +14875,31 @@
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Xml.ReaderWriter.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "Package",
       "files": [
+        "System.Xml.XDocument.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Xml.XDocument.dll",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/de/System.Xml.XDocument.xml",
         "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
@@ -14582,31 +14907,31 @@
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Xml.XDocument.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "Package",
       "files": [
+        "System.Xml.XmlDocument.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet/System.Xml.XmlDocument.dll",
         "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/de/System.Xml.XmlDocument.xml",
         "ref/dotnet/es/System.Xml.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XmlDocument.xml",
@@ -14614,22 +14939,18 @@
         "ref/dotnet/ja/System.Xml.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XmlDocument.xml",
-        "ref/dotnet/System.Xml.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Xml.XmlDocument.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Xml.XmlSerializer/4.0.10": {
       "sha512": "OKhE6vruk88z/hl0lmfrMvXteTASgJUagu6PT6S10i9uLbvDR3pTwB6jVgiwa2D2qtTB+eneZbS9jljhPXhTtg==",
       "type": "Package",
       "files": [
+        "System.Xml.XmlSerializer.nuspec",
         "[Content_Types].xml",
         "_rels/.rels",
         "lib/DNXCore50/System.Xml.XmlSerializer.dll",
@@ -14640,6 +14961,10 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "package/services/metadata/core-properties/1cffc42bca944f1d81ef3c3abdb0f0be.psmdcp",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Xml.XmlSerializer.dll",
+        "ref/dotnet/System.Xml.XmlSerializer.xml",
         "ref/dotnet/de/System.Xml.XmlSerializer.xml",
         "ref/dotnet/es/System.Xml.XmlSerializer.xml",
         "ref/dotnet/fr/System.Xml.XmlSerializer.xml",
@@ -14647,39 +14972,34 @@
         "ref/dotnet/ja/System.Xml.XmlSerializer.xml",
         "ref/dotnet/ko/System.Xml.XmlSerializer.xml",
         "ref/dotnet/ru/System.Xml.XmlSerializer.xml",
-        "ref/dotnet/System.Xml.XmlSerializer.dll",
-        "ref/dotnet/System.Xml.XmlSerializer.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlSerializer.xml",
         "ref/dotnet/zh-hant/System.Xml.XmlSerializer.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
-        "System.Xml.XmlSerializer.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll"
       ]
     },
     "Xamarin.Forms/2.0.1.6505": {
-      "sha512": "hmaHk7j3mWZY7rmWKq2/pnqDnbxFGQ20VXro2W2yaMS4ZDZBcQb6ePzH5/y0l6wRFgiPkA+oXPlrXbXICrE5hw==",
-      "type": "Package",
+      "sha512": "TBAEMEqugEwcEBtMo6PRqL3asZ6YmE3sJm4YoYnIy0nI8n1U7XwPkF/MUZu8Dl2qbAyqGjDxCgfYQrdI2cf7tw==",
+      "type": "package",
       "files": [
-        "[Content_Types].xml",
-        "_rels/.rels",
+        "Xamarin.Forms.2.0.1.6505.nupkg.sha512",
+        "Xamarin.Forms.nuspec",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.Decompiler.dll",
-        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.Cecil.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.CSharp.dll",
-        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.dll",
+        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.Cecil.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.Xml.dll",
-        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.dll",
+        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/ICSharpCode.NRefactory.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.Mdb.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.Pdb.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.Rocks.dll",
+        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Mono.Cecil.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Build.Tasks.dll",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Core.dll",
-        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets",
         "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Xaml.dll",
+        "build/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets",
         "lib/MonoAndroid10/FormsViewGroup.dll",
         "lib/MonoAndroid10/Xamarin.Forms.Core.dll",
         "lib/MonoAndroid10/Xamarin.Forms.Core.xml",
@@ -14693,6 +15013,18 @@
         "lib/MonoTouch10/Xamarin.Forms.Platform.iOS.Classic.dll",
         "lib/MonoTouch10/Xamarin.Forms.Xaml.dll",
         "lib/MonoTouch10/Xamarin.Forms.Xaml.xml",
+        "lib/WP80/Xamarin.Forms.Core.dll",
+        "lib/WP80/Xamarin.Forms.Core.xml",
+        "lib/WP80/Xamarin.Forms.Platform.WP8.dll",
+        "lib/WP80/Xamarin.Forms.Platform.dll",
+        "lib/WP80/Xamarin.Forms.Xaml.dll",
+        "lib/WP80/Xamarin.Forms.Xaml.xml",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Core.dll",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Core.xml",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Platform.dll",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Platform.iOS.dll",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Xaml.dll",
+        "lib/Xamarin.iOS10/Xamarin.Forms.Xaml.xml",
         "lib/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Core.dll",
         "lib/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Core.xml",
         "lib/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Platform.dll",
@@ -14700,7 +15032,6 @@
         "lib/portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.Xaml.xml",
         "lib/uap10.0/Xamarin.Forms.Core.dll",
         "lib/uap10.0/Xamarin.Forms.Core.xml",
-        "lib/uap10.0/Xamarin.Forms.Platform.dll",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP.dll",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP.pri",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP/FormsTextBox.xbf",
@@ -14708,34 +15039,27 @@
         "lib/uap10.0/Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP/Resources.xbf",
         "lib/uap10.0/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.xr.xml",
+        "lib/uap10.0/Xamarin.Forms.Platform.dll",
         "lib/uap10.0/Xamarin.Forms.Xaml.dll",
         "lib/uap10.0/Xamarin.Forms.Xaml.xml",
         "lib/win81/Xamarin.Forms.Core.dll",
         "lib/win81/Xamarin.Forms.Core.xml",
-        "lib/win81/Xamarin.Forms.Platform.dll",
-        "lib/win81/Xamarin.Forms.Platform.WinRT.dll",
-        "lib/win81/Xamarin.Forms.Platform.WinRT.pri",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet.dll",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet.pri",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet/Resources.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet/TabletResources.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT.Tablet/Xamarin.Forms.Platform.WinRT.Tablet.xr.xml",
+        "lib/win81/Xamarin.Forms.Platform.WinRT.dll",
+        "lib/win81/Xamarin.Forms.Platform.WinRT.pri",
         "lib/win81/Xamarin.Forms.Platform.WinRT/FormsTextBox.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT/PageControl.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT/StepperControl.xbf",
         "lib/win81/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.xr.xml",
+        "lib/win81/Xamarin.Forms.Platform.dll",
         "lib/win81/Xamarin.Forms.Xaml.dll",
         "lib/win81/Xamarin.Forms.Xaml.xml",
-        "lib/WP80/Xamarin.Forms.Core.dll",
-        "lib/WP80/Xamarin.Forms.Core.xml",
-        "lib/WP80/Xamarin.Forms.Platform.dll",
-        "lib/WP80/Xamarin.Forms.Platform.WP8.dll",
-        "lib/WP80/Xamarin.Forms.Xaml.dll",
-        "lib/WP80/Xamarin.Forms.Xaml.xml",
         "lib/wpa81/Xamarin.Forms.Core.dll",
         "lib/wpa81/Xamarin.Forms.Core.xml",
-        "lib/wpa81/Xamarin.Forms.Platform.dll",
-        "lib/wpa81/Xamarin.Forms.Platform.WinRT.dll",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone.dll",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone.pri",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone/FormsTextBoxStyle.xbf",
@@ -14743,24 +15067,18 @@
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone/Resources.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone/SearchBox.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.Phone/Xamarin.Forms.Platform.WinRT.Phone.xr.xml",
+        "lib/wpa81/Xamarin.Forms.Platform.WinRT.dll",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT.pri",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT/FormsTextBox.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT/PageControl.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT/StepperControl.xbf",
         "lib/wpa81/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.xr.xml",
+        "lib/wpa81/Xamarin.Forms.Platform.dll",
         "lib/wpa81/Xamarin.Forms.Xaml.dll",
         "lib/wpa81/Xamarin.Forms.Xaml.xml",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Core.dll",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Core.xml",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Platform.dll",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Platform.iOS.dll",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Xaml.dll",
-        "lib/Xamarin.iOS10/Xamarin.Forms.Xaml.xml",
-        "package/services/metadata/core-properties/a020f0c26e2c4330b18512b6bcf23b4e.psmdcp",
-        "tools/init.ps1",
         "tools/Xamarin.Forms.Core.Design.dll",
         "tools/Xamarin.Forms.Xaml.Design.dll",
-        "Xamarin.Forms.nuspec"
+        "tools/init.ps1"
       ]
     }
   },


### PR DESCRIPTION
Please take a moment to fill out the following (change to preview to check or place x in []):

Fixes # .

Changes Proposed in this pull request:

UWP Changes to using IImageSourceHandler instead of if(image.Sour as Type)

Work with All source Type

This fixes/implements:
- [X ] Bug
- [ X] Feature Request

Which plugin does this impact:
- [ ] Battery
- [ ] Connectivity
- [ ] Contacts
- [ ] DeviceInfo
- [ ] ExternalMaps
- [ ] Geolocator
- [ ] Media
- [ ] Permissions
- [ ] Settings
- [ ] Text To Speech
- [ ] Vibrate
- Other:
ImageCircle
