### PR TITLE
Allow setting the NSUserDefaults name for iOS implementation.

### DIFF
--- a/Settings/Refractored.Xam.Settings.iOS/Settings.cs
+++ b/Settings/Refractored.Xam.Settings.iOS/Settings.cs
@@ -28,7 +28,7 @@ namespace Plugin.Settings
         {
             lock (locker)
             {
-                var defaults = NSUserDefaults.StandardUserDefaults;
+                var defaults = GetDefaults();
 
                 if (defaults.ValueForKey(new NSString(key)) == null)
                     return defaultValue;
@@ -145,7 +145,7 @@ namespace Plugin.Settings
         {
             lock (locker)
             {
-                var defaults = NSUserDefaults.StandardUserDefaults;
+                var defaults = GetDefaults();
                 switch (typeCode)
                 {
                     case TypeCode.Decimal:
@@ -208,7 +208,7 @@ namespace Plugin.Settings
         {
             lock (locker)
             {
-                var defaults = NSUserDefaults.StandardUserDefaults;
+                var defaults = GetDefaults();
                 try
                 {
                     var nsString = new NSString(key);
@@ -225,6 +225,11 @@ namespace Plugin.Settings
             }
         }
 
+        private NSUserDefaults GetDefaults()
+        {
+            return string.IsNullOrWhiteSpace(CrossSettings.DefaultsName) ? NSUserDefaults.StandardUserDefaults
+                : new NSUserDefaults(CrossSettings.DefaultsName, NSUserDefaultsType.SuiteName);
+        }
     }
 
 }

--- a/Settings/Refractored.Xam.Settings/CrossSettings.cs
+++ b/Settings/Refractored.Xam.Settings/CrossSettings.cs
@@ -36,6 +36,10 @@ namespace Plugin.Settings
             }
         }
 
+#if __IOS__
+        public static string DefaultsName { get; set; }
+#endif
+
         static ISettings CreateSettings()
         {
 #if PORTABLE


### PR DESCRIPTION
Please take a moment to fill out the following (change to preview to check or place x in []):

Fixes #309.

Changes Proposed in this pull request:
- The usage of app groups that share NSUserDefaults is not possible with the current implementation. This PR adds that ability to set a static `DefaultsName` so that it can be shared within an app group. See https://developer.xamarin.com/guides/ios/watch/working-with/parent-app/#Shared_Storage

This fixes/implements:
- [] Bug
- [x] Feature Request

Which plugin does this impact:
- [] Battery
- [] Connectivity
- [] Contacts
- [] DeviceInfo
- [] ExternalMaps
- [] Geolocator
- [] Media
- [] Permissions
- [x] Settings
- [] Text To Speech
- [] Vibrate
- Other:
